### PR TITLE
support unlogged tables

### DIFF
--- a/dbcrossbarlib/src/drivers/postgres_shared/create_table_sql.rustpeg
+++ b/dbcrossbarlib/src/drivers/postgres_shared/create_table_sql.rustpeg
@@ -15,7 +15,7 @@ use crate::schema::Srid;
 
 /// A `CREATE TABLE` expression.
 pub create_table -> PgCreateTable
-    = ws? "CREATE"i ws "TABLE"i ws name:identifier ws? "("
+    = ws? "CREATE"i (ws "UNLOGGED"i)? ws "TABLE"i ws name:identifier ws? "("
         ws? columns:(column ** (ws? "," ws?)) ws?
       ")" ws? (";" ws?)?
     {

--- a/dbcrossbarlib/src/drivers/postgres_shared/create_table_sql.rustpeg
+++ b/dbcrossbarlib/src/drivers/postgres_shared/create_table_sql.rustpeg
@@ -15,7 +15,7 @@ use crate::schema::Srid;
 
 /// A `CREATE TABLE` expression.
 pub create_table -> PgCreateTable
-    = ws? "CREATE"i (ws "UNLOGGED"i)? ws "TABLE"i ws name:identifier ws? "("
+    = ws? "CREATE"i ws ("UNLOGGED"i ws)? "TABLE"i ws name:identifier ws? "("
         ws? columns:(column ** (ws? "," ws?)) ws?
       ")" ws? (";" ws?)?
     {


### PR DESCRIPTION
sometimes you want `CREATE UNLOGGED TABLE`

```
Error: error parsing Postgres `CREATE TABLE`
  caused by: error at 1:8: expected `TABLE`
```