### PR TITLE
Allow overriding BigQuery temp dataset name

### DIFF
--- a/dbcrossbar/src/cmd/cp.rs
+++ b/dbcrossbar/src/cmd/cp.rs
@@ -40,6 +40,10 @@ pub(crate) async fn run(ctx: Context, opt: Opt) -> Result<()> {
         })
     }?;
 
+    // Build a `TemporaryStorage` object to keep track of places that we can put
+    // temporary data.
+    let temporary_storage = TemporaryStorage::new(opt.temporaries.clone());
+
     // Can we short-circuit this particular copy using special features of the
     // the source and destination, or do we need to pull the data down to the
     // local machine?
@@ -59,13 +63,13 @@ pub(crate) async fn run(ctx: Context, opt: Opt) -> Result<()> {
             ctx,
             schema,
             opt.from_locator,
+            temporary_storage,
             opt.if_exists,
         ))?
     } else {
         // We have to transfer the data via the local machine, so read data from
         // input.
         debug!(ctx.log(), "performaning local data transfer");
-        let temporary_storage = TemporaryStorage::new(opt.temporaries.clone());
 
         let input_ctx = ctx.child(o!("from_locator" => opt.from_locator.to_string()));
         let data = await!(opt.from_locator.local_data(

--- a/dbcrossbar/tests/tests.rs
+++ b/dbcrossbar/tests/tests.rs
@@ -46,9 +46,14 @@ fn gs_test_dir_url(dir_name: &str) -> String {
 }
 
 /// A BigQuery table to use for a test.
-fn bq_test_table(table_name: &str) -> String {
+fn bq_temp_dataset() -> String {
     let dataset = env::var("BQ_TEST_DATASET").expect("BQ_TEST_DATASET must be set");
-    format!("bigquery:{}.{}", dataset, table_name)
+    format!("bigquery:{}", dataset)
+}
+
+/// A BigQuery table to use for a test.
+fn bq_test_table(table_name: &str) -> String {
+    format!("{}.{}", bq_temp_dataset(), table_name)
 }
 
 #[test]
@@ -296,6 +301,7 @@ fn cp_csv_to_bigquery_to_csv() {
     let testdir = TestDir::new("dbcrossbar", "cp_csv_to_bigquery_to_csv");
     let src = testdir.src_path("fixtures/many_types.csv");
     let schema = testdir.src_path("fixtures/many_types.sql");
+    let bq_temp_ds = bq_temp_dataset();
     let gs_temp_dir = gs_test_dir_url("cp_csv_to_bigquery_to_csv");
     let bq_table = bq_test_table("cp_csv_to_bigquery_to_csv");
 
@@ -306,6 +312,7 @@ fn cp_csv_to_bigquery_to_csv() {
             "cp",
             "--if-exists=overwrite",
             &format!("--temporary={}", gs_temp_dir),
+            &format!("--temporary={}", bq_temp_ds),
             &format!("--schema=postgres-sql:{}", schema.display()),
             &format!("csv:{}", src.display()),
             &bq_table,
@@ -320,6 +327,7 @@ fn cp_csv_to_bigquery_to_csv() {
             "cp",
             "--if-exists=overwrite",
             &format!("--temporary={}", gs_temp_dir),
+            &format!("--temporary={}", bq_temp_ds),
             &bq_table,
             "csv:out/",
         ])

--- a/dbcrossbarlib/src/drivers/bigquery/local_data.rs
+++ b/dbcrossbarlib/src/drivers/bigquery/local_data.rs
@@ -20,6 +20,7 @@ pub(crate) async fn local_data_helper(
         to_temp_ctx,
         schema.clone(),
         Box::new(source),
+        temporary_storage.clone(),
         IfExists::Overwrite,
     ))?;
 

--- a/dbcrossbarlib/src/drivers/bigquery/mod.rs
+++ b/dbcrossbarlib/src/drivers/bigquery/mod.rs
@@ -130,10 +130,18 @@ impl Locator for BigQueryLocator {
         ctx: Context,
         schema: Table,
         source: BoxLocator,
+        temporary_storage: TemporaryStorage,
         if_exists: IfExists,
     ) -> BoxFuture<()> {
-        write_remote_data_helper(ctx, schema, source, self.to_owned(), if_exists)
-            .into_boxed()
+        write_remote_data_helper(
+            ctx,
+            schema,
+            source,
+            self.to_owned(),
+            temporary_storage,
+            if_exists,
+        )
+        .into_boxed()
     }
 }
 

--- a/dbcrossbarlib/src/drivers/bigquery/write_local_data.rs
+++ b/dbcrossbarlib/src/drivers/bigquery/write_local_data.rs
@@ -39,7 +39,8 @@ pub(crate) async fn write_local_data_helper(
         from_temp_ctx,
         schema,
         Box::new(gs_temp),
-        if_exists
+        temporary_storage,
+        if_exists,
     ))?;
 
     // We don't need any parallelism after the BigQuery step, so just return

--- a/dbcrossbarlib/src/drivers/bigquery/write_remote_data.rs
+++ b/dbcrossbarlib/src/drivers/bigquery/write_remote_data.rs
@@ -25,6 +25,7 @@ pub(crate) async fn write_remote_data_helper(
     schema: Table,
     source: BoxLocator,
     dest: BigQueryLocator,
+    temporary_storage: TemporaryStorage,
     if_exists: IfExists,
 ) -> Result<()> {
     // Convert the source locator into the underlying `gs://` URL. This is a bit
@@ -50,7 +51,8 @@ pub(crate) async fn write_remote_data_helper(
 
     // Decide if we need to use a temp table.
     let (use_temp, initial_table_name) = if !schema.bigquery_can_import_from_csv()? {
-        let initial_table_name = dest.table_name.temporary_table_name();
+        let initial_table_name =
+            dest.table_name.temporary_table_name(&temporary_storage)?;
         debug!(
             ctx.log(),
             "loading into temporary table {}", initial_table_name

--- a/dbcrossbarlib/src/drivers/gs/mod.rs
+++ b/dbcrossbarlib/src/drivers/gs/mod.rs
@@ -94,9 +94,17 @@ impl Locator for GsLocator {
         ctx: Context,
         schema: Table,
         source: BoxLocator,
+        temporary_storage: TemporaryStorage,
         if_exists: IfExists,
     ) -> BoxFuture<()> {
-        write_remote_data_helper(ctx, schema, source, self.to_owned(), if_exists)
-            .into_boxed()
+        write_remote_data_helper(
+            ctx,
+            schema,
+            source,
+            self.to_owned(),
+            temporary_storage,
+            if_exists,
+        )
+        .into_boxed()
     }
 }

--- a/dbcrossbarlib/src/drivers/gs/write_remote_data.rs
+++ b/dbcrossbarlib/src/drivers/gs/write_remote_data.rs
@@ -21,6 +21,7 @@ pub(crate) async fn write_remote_data_helper(
     schema: Table,
     source: BoxLocator,
     dest: GsLocator,
+    temporary_storage: TemporaryStorage,
     if_exists: IfExists,
 ) -> Result<()> {
     // Convert the source locator into the underlying `TableName. This is a bit
@@ -41,7 +42,9 @@ pub(crate) async fn write_remote_data_helper(
     )?;
 
     // We need to build a temporary export table.
-    let temp_table_name = source_table.name().temporary_table_name();
+    let temp_table_name = source_table
+        .name()
+        .temporary_table_name(&temporary_storage)?;
     let mut export_sql_data = vec![];
     source_table.write_export_sql(&mut export_sql_data)?;
     let export_sql =

--- a/dbcrossbarlib/src/locator.rs
+++ b/dbcrossbarlib/src/locator.rs
@@ -122,6 +122,7 @@ pub trait Locator: fmt::Debug + fmt::Display + Send + Sync + 'static {
         _ctx: Context,
         _schema: Table,
         source: BoxLocator,
+        _temporary_storage: TemporaryStorage,
         _if_exists: IfExists,
     ) -> BoxFuture<()> {
         Err(format_err!(


### PR DESCRIPTION
You can now pass `--temporary=bigquery:proj:dataset`, and that dataset
will be used for storing temporary tables. This makes it possible to set
automatic expiration and it makes it possible to only put "real" tables
inside the final destination dataset.