### PR TITLE
s3: Implement basic S3 driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Right now, certain drivers still have restrictions on what column types are supp
 
 ## Architecture
 
-`dbcrossbar` is written using nightly Rust, including `tokio`, `async` and `await!`. It uses multiple CSV streams to transfer data between databases.
+`dbcrossbar` is written using nightly Rust, including `tokio`, `async` and `.await`. It uses multiple CSV streams to transfer data between databases.
 
 It uses a very specific "interchange CSV" format, supporting the types listed in [`schema.rs`](./dbcrossbarlib/src/schema.rs). In a few cases, it supports purely cloud-based transfers, such as when importing `gs://**/*.csv` URLs into BigQuery.
 
@@ -122,10 +122,11 @@ export POSTGRES_TEST_URL=postgres://postgres:@localhost:5432/dbcrossbar_test
 echo "create extension if not exists postgis;" | psql $POSTGRES_TEST_URL
 
 # Point to a Goolge Cloud Storage bucket for which you have write permissions.
-export GS_TEST_URL=gs://$MY_TEST_BUCKET/dbcrossbar/
-export BQ_TEST_DATASET=$MY_ROOT:test
+export GS_TEST_URL=gs://$MY_GS_TEST_BUCKET/dbcrossbar/
+export BQ_TEST_DATASET=$MY_BQ_ROOT:test
+export S3_TEST_URL=s3://$MT_S3_TEST_BUCKET/dbcrossbar/
 
 # Run the integration tests.
-env RUST_BACKTRACE=1 RUST_LOG=warn,dbcrossbarlib=trace,dbcrossbar=trace \
+env RUST_BACKTRACE=1 RUST_LOG=warn,dbcrossbarlib=debug,dbcrossbar=debug \
     cargo test --all -- --ignored --nocapture
 ```

--- a/dbcrossbarlib/src/csv_stream.rs
+++ b/dbcrossbarlib/src/csv_stream.rs
@@ -9,3 +9,68 @@ pub struct CsvStream {
     /// A reader associated with this stream.
     pub data: Box<dyn Stream<Item = BytesMut, Error = Error> + Send + 'static>,
 }
+
+/// Given a `base_path` refering to one of more CSV files, and a `file_path`
+/// refering to a single CSV file, figure out the best name to use for a
+/// `CsvStream` for that CSV file.
+pub(crate) fn csv_stream_name<'a>(
+    base_path: &str,
+    file_path: &'a str,
+) -> Result<&'a str> {
+    let basename_or_relative = if file_path == base_path {
+        // Our base_path and our file_path are the same, which means that we had
+        // only a single input, and we therefore want to extract the "basename",
+        // or filename without any directories.
+        file_path
+            .rsplitn(2, '/')
+            .next()
+            .expect("should have '/' in URL")
+    } else if base_path.ends_with('/') && file_path.starts_with(base_path) {
+        // Our file_path starts with our base_path, which means that we have an
+        // entire directory tree full of files and this is one. This means we
+        // want to take the relative path within this directory.
+        &file_path[base_path.len()..]
+    } else {
+        return Err(format_err!(
+            "expected {} to start with {}",
+            file_path,
+            base_path
+        ));
+    };
+
+    // Now strip any extension.
+    let name = basename_or_relative
+        .splitn(2, '.')
+        .next()
+        .ok_or_else(|| format_err!("can't get basename of {}", file_path))?;
+    Ok(name)
+}
+
+#[test]
+fn csv_stream_name_handles_file_inputs() {
+    let expected = &[
+        ("/path/to/file1.csv", "file1"),
+        ("file2.csv", "file2"),
+        ("s3://bucket/dir/file3.csv", "file3"),
+        ("gs://bucket/dir/file4.csv", "file4"),
+    ];
+    for &(file_path, stream_name) in expected {
+        assert_eq!(csv_stream_name(file_path, file_path).unwrap(), stream_name);
+    }
+}
+
+#[test]
+fn csv_stream_name_handles_directory_inputs() {
+    let expected = &[
+        ("dir/", "dir/file1.csv", "file1"),
+        ("dir/", "dir/subdir/file2.csv", "subdir/file2"),
+        (
+            "s3://bucket/dir/",
+            "s3://bucket/dir/subdir/file3.csv",
+            "subdir/file3",
+        ),
+    ];
+    for &(base_path, file_path, stream_name) in expected {
+        assert_eq!(csv_stream_name(base_path, file_path).unwrap(), stream_name);
+    }
+}

--- a/dbcrossbarlib/src/drivers/csv/mod.rs
+++ b/dbcrossbarlib/src/drivers/csv/mod.rs
@@ -173,11 +173,13 @@ async fn write_local_data_helper(
                     // particularly safe fashion.
                     let csv_path = path.join(&format!("{}.csv", stream.name));
                     let ctx = ctx.child(o!("stream" => stream.name.clone(), "path" => format!("{}", csv_path.display())));
+                    debug!(ctx.log(), "writing CSV stream to file");
                     let wtr = if_exists
                         .to_async_open_options_no_append()?
                         .open(csv_path.clone())
                         .compat()
-                        .await?;
+                        .await
+                        .with_context(|_| format!("cannot open {}", csv_path.display()))?;
                     copy_stream_to_writer(ctx.clone(), stream.data, wtr).await.with_context(
                         |_| format!("error writing {}", csv_path.display()),
                     )?;

--- a/dbcrossbarlib/src/drivers/mod.rs
+++ b/dbcrossbarlib/src/drivers/mod.rs
@@ -10,3 +10,4 @@ pub mod gs;
 pub mod postgres;
 pub mod postgres_shared;
 pub mod postgres_sql;
+pub mod s3;

--- a/dbcrossbarlib/src/drivers/s3/local_data.rs
+++ b/dbcrossbarlib/src/drivers/s3/local_data.rs
@@ -81,7 +81,8 @@ pub(crate) async fn local_data_helper(
 
 /// Given an S3 URL, get the URL for just the bucket itself.
 fn bucket_url(url: &Url) -> Result<Url> {
-    let bucket = url.host()
+    let bucket = url
+        .host()
         .ok_or_else(|| format_err!("could not find bucket name in {}", url))?;
     let bucket_url = format!("s3://{}/", bucket)
         .parse::<Url>()

--- a/dbcrossbarlib/src/drivers/s3/local_data.rs
+++ b/dbcrossbarlib/src/drivers/s3/local_data.rs
@@ -1,0 +1,133 @@
+//! Reading data from AWS S3.
+
+use lazy_static::lazy_static;
+use regex::Regex;
+use std::{
+    io::BufReader,
+    process::{Command, Stdio},
+};
+use tokio::io;
+use tokio_process::CommandExt;
+
+use crate::common::*;
+use crate::csv_stream::csv_stream_name;
+use crate::tokio_glue::copy_reader_to_stream;
+
+/// Implementation of `local_data`, but as a real `async` function.
+pub(crate) async fn local_data_helper(
+    ctx: Context,
+    url: Url,
+    query: Query,
+) -> Result<Option<BoxStream<CsvStream>>> {
+    query.fail_if_query_details_provided()?;
+    debug!(ctx.log(), "getting CSV files from {}", url);
+
+    // Start a child process to list files at that URL.
+    debug!(ctx.log(), "listing {}", url);
+    let mut child = Command::new("aws")
+        .args(&["s3", "ls", "--recursive", url.as_str()])
+        .stdout(Stdio::piped())
+        .spawn_async()
+        .context("error running `aws s3 ls`")?;
+    let child_stdout = child.stdout().take().expect("child should have stdout");
+    ctx.spawn_process(format!("aws s3 ls {}", url), child);
+
+    // Parse `ls` output into lines, and convert into `CsvStream` values lazily
+    // in case there are a lot of CSV files we need to read.
+    //
+    // XXX - This will fail (either silently or noisily, I'm not sure) if there
+    // are 1000+ files in the S3 directory, and we can't fix this without
+    // switching from `aws s3` to native S3 API calls from Rust.
+    let lines = io::lines(BufReader::with_capacity(BUFFER_SIZE, child_stdout))
+        .map_err(|e| format_err!("error reading `aws s3 ls` output: {}", e));
+    let csv_streams = lines.and_then(move |line| -> BoxFuture<CsvStream> {
+        let ctx = ctx.clone();
+        let url = url.clone();
+        async move {
+            trace!(ctx.log(), "`aws s3 ls` line: {}", line);
+            let bucket_url = bucket_url(&url)?;
+            let path = path_from_line(&line)?;
+            let file_url = bucket_url.join(&path)?;
+
+            // Stream the file from the cloud.
+            let name = csv_stream_name(url.as_str(), file_url.as_str())?;
+            let ctx = ctx.child(
+                o!("stream" => name.to_owned(), "url" => file_url.as_str().to_owned()),
+            );
+            debug!(ctx.log(), "streaming from {} using `aws s3 cp`", file_url);
+            let mut child = Command::new("aws")
+                .args(&["s3", "cp", file_url.as_str(), "-"])
+                .stdout(Stdio::piped())
+                .spawn_async()
+                .context("error running `aws s3 cp`")?;
+            let child_stdout =
+                child.stdout().take().expect("child should have stdout");
+            let child_stdout = BufReader::with_capacity(BUFFER_SIZE, child_stdout);
+            let data = copy_reader_to_stream(ctx.clone(), child_stdout)?;
+            ctx.spawn_process(format!("aws s3 cp {} -", file_url), child);
+
+            // Assemble everything into a CSV stream.
+            Ok(CsvStream {
+                name: name.to_owned(),
+                data: Box::new(data),
+            })
+        }
+            .boxed()
+            .compat()
+    });
+
+    Ok(Some(Box::new(csv_streams) as BoxStream<CsvStream>))
+}
+
+/// Given an S3 URL, get the URL for just the bucket itself.
+fn bucket_url(url: &Url) -> Result<Url> {
+    let bucket = url.host()
+        .ok_or_else(|| format_err!("could not find bucket name in {}", url))?;
+    let bucket_url = format!("s3://{}/", bucket)
+        .parse::<Url>()
+        .context("could not parse S3 URL")?;
+    Ok(bucket_url)
+}
+
+#[test]
+fn bucket_url_extracts_bucket() {
+    let examples = &[
+        ("s3://bucket", "s3://bucket/"),
+        ("s3://bucket/", "s3://bucket/"),
+        ("s3://bucket/dir/", "s3://bucket/"),
+        ("s3://bucket/dir/file.csv", "s3://bucket/"),
+    ];
+    for &(url, expected) in examples {
+        assert_eq!(
+            bucket_url(&url.parse::<Url>().unwrap()).unwrap().as_str(),
+            expected,
+        );
+    }
+}
+
+/// Given a line of `aws s3 ls` output, extract the path.
+fn path_from_line(line: &str) -> Result<String> {
+    lazy_static! {
+        static ref RE: Regex = Regex::new(r#"^[-0-9]+ [:0-9]+ +[0-9]+ ([^\r\n]+)"#)
+            .expect("invalid regex in source");
+    }
+    let cap = RE
+        .captures(line)
+        .ok_or_else(|| format_err!("cannot parse S3 ls output: {:?}", line))?;
+    Ok(cap[1].to_owned())
+}
+
+#[test]
+fn path_from_line_returns_entire_path() {
+    let examples = &[
+        ("2013-09-02 21:37:53         10 a.txt", "a.txt"),
+        ("2013-09-02 21:37:53    2863288 foo.zip", "foo.zip"),
+        (
+            "2013-09-02 21:32:57         23 foo/bar/.baz/a",
+            "foo/bar/.baz/a",
+        ),
+    ];
+    for &(line, rel_path) in examples {
+        assert_eq!(path_from_line(line).unwrap(), rel_path);
+    }
+}

--- a/dbcrossbarlib/src/drivers/s3/mod.rs
+++ b/dbcrossbarlib/src/drivers/s3/mod.rs
@@ -1,0 +1,79 @@
+//! Support for Amazon's S3.
+
+use std::{fmt, str::FromStr};
+
+use crate::common::*;
+
+mod local_data;
+mod prepare_as_destination;
+mod write_local_data;
+
+use local_data::local_data_helper;
+pub(crate) use prepare_as_destination::prepare_as_destination_helper;
+use write_local_data::write_local_data_helper;
+
+/// Locator scheme for S3.
+pub(crate) const S3_SCHEME: &str = "s3:";
+
+#[derive(Clone, Debug)]
+pub(crate) struct S3Locator {
+    url: Url,
+}
+
+impl fmt::Display for S3Locator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.url.fmt(f)
+    }
+}
+
+impl FromStr for S3Locator {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        if s.starts_with(S3_SCHEME) {
+            let url = s
+                .parse::<Url>()
+                .with_context(|_| format!("cannot parse {}", s))?;
+            if !url.path().starts_with('/') {
+                Err(format_err!("{} must start with s3://", url))
+            } else if !url.path().ends_with('/') {
+                Err(format_err!("{} must end with a '/'", url))
+            } else {
+                Ok(S3Locator { url })
+            }
+        } else {
+            Err(format_err!("expected {} to begin with s3://", s))
+        }
+    }
+}
+
+impl Locator for S3Locator {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn local_data(
+        &self,
+        ctx: Context,
+        _schema: Table,
+        query: Query,
+        _temporary_storage: TemporaryStorage,
+    ) -> BoxFuture<Option<BoxStream<CsvStream>>> {
+        local_data_helper(ctx, self.url.clone(), query)
+            .boxed()
+            .compat()
+    }
+
+    fn write_local_data(
+        &self,
+        ctx: Context,
+        schema: Table,
+        data: BoxStream<CsvStream>,
+        _temporary_storage: TemporaryStorage,
+        if_exists: IfExists,
+    ) -> BoxFuture<BoxStream<BoxFuture<()>>> {
+        write_local_data_helper(ctx, self.url.clone(), schema, data, if_exists)
+            .boxed()
+            .compat()
+    }
+}

--- a/dbcrossbarlib/src/drivers/s3/prepare_as_destination.rs
+++ b/dbcrossbarlib/src/drivers/s3/prepare_as_destination.rs
@@ -1,0 +1,42 @@
+//! Preparing bucket directories as output destinations.
+
+use std::process::Command;
+use tokio_process::CommandExt;
+
+use crate::common::*;
+
+/// Prepare the target of this locator for use as a destination.
+pub(crate) async fn prepare_as_destination_helper(
+    ctx: Context,
+    s3_url: Url,
+    if_exists: IfExists,
+) -> Result<()> {
+    // Delete the existing output, if it exists.
+    if if_exists == IfExists::Overwrite {
+        // Delete all the files under `self.url`.
+        debug!(ctx.log(), "deleting existing {}", s3_url);
+        if !s3_url.path().ends_with('/') {
+            return Err(format_err!(
+                "can only write to s3:// URL ending in '/', got {}",
+                s3_url,
+            ));
+        }
+        let status = Command::new("aws")
+            .args(&["s3", "rm", "--recursive", s3_url.as_str()])
+            .status_async()
+            .context("error running `aws s3`")?;
+        if !status.compat().await?.success() {
+            warn!(
+                ctx.log(),
+                "can't delete contents of {}, possibly because it doesn't exist",
+                s3_url,
+            );
+        }
+        Ok(())
+    } else {
+        Err(format_err!(
+            "must specify `overwrite` for {} destination",
+            s3_url,
+        ))
+    }
+}

--- a/dbcrossbarlib/src/drivers/s3/write_local_data.rs
+++ b/dbcrossbarlib/src/drivers/s3/write_local_data.rs
@@ -1,4 +1,4 @@
-//! Writing data to Google Cloud Storage.
+//! Writing data to AWS S3.
 
 use std::process::{Command, Stdio};
 use tokio_process::CommandExt;
@@ -18,7 +18,7 @@ pub(crate) async fn write_local_data_helper(
     // Delete the existing output, if it exists.
     prepare_as_destination_helper(ctx.clone(), url.clone(), if_exists).await?;
 
-    // Spawn our uploader processes.
+    // Spawn our uploader threads.
     let written = data.map(move |stream| {
         let url = url.clone();
         let ctx = ctx.clone();
@@ -27,21 +27,21 @@ pub(crate) async fn write_local_data_helper(
             let ctx = ctx
                 .child(o!("stream" => stream.name.clone(), "url" => url.to_string()));
 
-            // Run `gsutil cp - $URL` as a background process.
-            debug!(ctx.log(), "uploading stream to gsutil");
-            let mut child = Command::new("gsutil")
-                .args(&["cp", "-", url.as_str()])
+            // Run `aws cp - $URL` as a background process.
+            debug!(ctx.log(), "uploading stream to `aws s3`");
+            let mut child = Command::new("aws")
+                .args(&["s3", "cp", "-", url.as_str()])
                 .stdin(Stdio::piped())
                 .spawn_async()
-                .context("error running gsutil")?;
+                .context("error running `aws s3`")?;
             let child_stdin = child.stdin().take().expect("child should have stdin");
 
             // Copy data to our child process.
             copy_stream_to_writer(ctx.clone(), stream.data, child_stdin)
                 .await
-                .context("error copying data to gsutil")?;
+                .context("error copying data to `aws s3`")?;
 
-            // Wait for `gsutil` to finish.
+            // Wait for `aws s3` to finish.
             let status = child
                 .compat()
                 .await
@@ -49,7 +49,7 @@ pub(crate) async fn write_local_data_helper(
             if status.success() {
                 Ok(())
             } else {
-                Err(format_err!("gsutil returned error: {}", status))
+                Err(format_err!("`aws s3` returned error: {}", status))
             }
         }
             .boxed()

--- a/dbcrossbarlib/src/locator.rs
+++ b/dbcrossbarlib/src/locator.rs
@@ -141,12 +141,12 @@ impl FromStr for BoxLocator {
     fn from_str(s: &str) -> Result<Self> {
         use crate::drivers::{
             bigquery::*, bigquery_schema::*, csv::*, gs::*, postgres::*,
-            postgres_sql::*,
+            postgres_sql::*, s3::*,
         };
 
         // Parse our locator into a URL-style scheme and the rest.
         lazy_static! {
-            static ref SCHEME_RE: Regex = Regex::new("^[A-Za-z][-A-Za-z0-0+.]*:")
+            static ref SCHEME_RE: Regex = Regex::new("^[A-Za-z][-A-Za-z0-9+.]*:")
                 .expect("invalid regex in source");
         }
         let cap = SCHEME_RE
@@ -164,6 +164,7 @@ impl FromStr for BoxLocator {
             GS_SCHEME => Ok(Box::new(GsLocator::from_str(s)?)),
             POSTGRES_SCHEME => Ok(Box::new(PostgresLocator::from_str(s)?)),
             POSTGRES_SQL_SCHEME => Ok(Box::new(PostgresSqlLocator::from_str(s)?)),
+            S3_SCHEME => Ok(Box::new(S3Locator::from_str(s)?)),
             _ => Err(format_err!("unknown locator scheme in {:?}", s)),
         }
     }
@@ -179,6 +180,7 @@ fn locator_from_str_to_string_roundtrip() {
         "gs://example-bucket/tmp/",
         "postgres://localhost:5432/db#my_table",
         "postgres-sql:dir/my_table.sql",
+        "s3://example/my-dir/",
     ];
     for locator in locators.into_iter() {
         let parsed: BoxLocator = locator.parse().unwrap();


### PR DESCRIPTION
This shells out to `aws s3 ls`, which means that we can't handle buckets of 1,000+ files correctly. But it accomplishes the basics.

@seamusabshere I'm going to merge this immediately, but I think it would be an excellent idea to review it anyway, because this shows how to implement an entire `dbcrossbar` driver from scratch by wrapping a CLI tool, and somebody but me should see how that works. Skill transfer is important!