### PR TITLE
Remove `Compat` wrapper from `BoxFuture<T>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "atty"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -62,15 +62,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "backtrace"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace-sys 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -134,7 +134,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-automata 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -197,7 +197,7 @@ version = "2.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "atty 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -341,7 +341,7 @@ dependencies = [
  "csv-core 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -398,7 +398,7 @@ dependencies = [
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -432,8 +432,8 @@ dependencies = [
  "peg 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -516,7 +516,7 @@ name = "env_logger"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "atty 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -528,7 +528,7 @@ name = "failure"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -698,7 +698,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "geo-types 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -951,7 +951,7 @@ name = "num-integer"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -960,7 +960,7 @@ name = "num-traits"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -999,7 +999,7 @@ name = "openssl-sys"
 version = "0.9.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1162,7 +1162,7 @@ name = "rand"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1192,7 +1192,7 @@ name = "rand_chacha"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1201,7 +1201,7 @@ name = "rand_chacha"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1279,7 +1279,7 @@ name = "rand_pcg"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1444,12 +1444,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.94"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.94"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1464,7 +1464,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1561,7 +1561,7 @@ name = "slog-term"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "atty 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2184,10 +2184,10 @@ dependencies = [
 "checksum arc-swap 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "bc4662175ead9cd84451d5c35070517777949a2ed84551764129cedb88384841"
 "checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"
 "checksum arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba"
-"checksum atty 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ecaaea69f52b3b18633611ec0007d188517d0366f47ff703d400fa6879d6f8d5"
-"checksum autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf"
-"checksum backtrace 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)" = "18b50f5258d1a9ad8396d2d345827875de4261b158124d4c819d9b351454fae5"
-"checksum backtrace-sys 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)" = "5b3a000b9c543553af61bc01cbfc403b04b5caa9e421033866f2e98061eb3e61"
+"checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
+"checksum autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "22130e92352b948e7e82a49cdb0aa94f2211761117f29e052dd397c1ac33542b"
+"checksum backtrace 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)" = "88fb679bc9af8fa639198790a77f52d345fe13656c08b43afa9424c206b731c6"
+"checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
@@ -2343,8 +2343,8 @@ dependencies = [
 "checksum security-framework-sys 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9636f8989cbf61385ae4824b98c1aaa54c994d7d8b41f11c601ed799f0549a56"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)" = "076a696fdea89c19d3baed462576b8f6d663064414b5c793642da8dfeb99475b"
-"checksum serde_derive 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)" = "ef45eb79d6463b22f5f9e16d283798b7c0175ba6050bc25c1a946c122727fe7b"
+"checksum serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)" = "d46b3dfedb19360a74316866cef04687cd4d6a70df8e6a506c63512790769b72"
+"checksum serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)" = "c22a0820adfe2f257b098714323563dd06426502abbbce4f51b72ef544c5027f"
 "checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
 "checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
 "checksum signal-hook 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4f61c4d59f3aaa9f61bba6450a9b80ba48362fd7d651689e7a10c453b1f6dc68"

--- a/dbcrossbar/src/cmd/cp.rs
+++ b/dbcrossbar/src/cmd/cp.rs
@@ -3,7 +3,7 @@
 use common_failures::Result;
 use dbcrossbarlib::{BoxLocator, Context, IfExists, Query, TemporaryStorage};
 use failure::format_err;
-use futures::compat::Future01CompatExt;
+use futures::{compat::Future01CompatExt, FutureExt, TryFutureExt};
 use slog::{debug, o};
 use structopt::{self, StructOpt};
 use tokio::prelude::*;
@@ -76,7 +76,6 @@ pub(crate) async fn run(ctx: Context, opt: Opt) -> Result<()> {
                 temporary_storage,
                 opt.if_exists,
             )
-            .compat()
             .await?
     } else {
         // We have to transfer the data via the local machine, so read data from
@@ -87,7 +86,6 @@ pub(crate) async fn run(ctx: Context, opt: Opt) -> Result<()> {
         let data = opt
             .from_locator
             .local_data(input_ctx, schema.clone(), query, temporary_storage.clone())
-            .compat()
             .await?
             .ok_or_else(|| {
                 format_err!("don't know how to read data from {}", opt.from_locator)
@@ -104,14 +102,23 @@ pub(crate) async fn run(ctx: Context, opt: Opt) -> Result<()> {
                 temporary_storage,
                 opt.if_exists,
             )
-            .compat()
             .await?;
 
         // Consume the stream of futures produced by `write_local_data`, allowing a
         // certain degree of parallelism. This is where all the actual work happens,
         // and this what controls how many "input driver" -> "output driver"
         // connections are running at any given time.
-        result_stream.buffered(4).collect().compat().await?;
+        result_stream
+            // This stream contains std futures, but we need tokio futures for
+            // `buffered`.
+            .map(|fut| fut.compat())
+            .buffered(4)
+            .collect()
+            .compat()
+            // This `boxed` is needed to prevent weird lifetime issues from
+            // seeping into the type of this function.
+            .boxed()
+            .await?;
     }
 
     Ok(())

--- a/dbcrossbar/src/cmd/mod.rs
+++ b/dbcrossbar/src/cmd/mod.rs
@@ -1,7 +1,7 @@
 //! Command parsing.
 
 use dbcrossbarlib::{tokio_glue::BoxFuture, Context};
-use futures::{FutureExt, TryFutureExt};
+use futures::FutureExt;
 //use structopt::StructOpt;
 use structopt_derive::StructOpt;
 
@@ -39,7 +39,7 @@ pub(crate) enum Opt {
 
 pub(crate) fn run(ctx: Context, opt: Opt) -> BoxFuture<()> {
     match opt {
-        Opt::Conv { command } => conv::run(ctx, command).boxed().compat(),
-        Opt::Cp { command } => cp::run(ctx, command).boxed().compat(),
+        Opt::Conv { command } => conv::run(ctx, command).boxed(),
+        Opt::Cp { command } => cp::run(ctx, command).boxed(),
     }
 }

--- a/dbcrossbar/src/main.rs
+++ b/dbcrossbar/src/main.rs
@@ -73,7 +73,7 @@ fn run() -> Result<()> {
     // If a background worker fails, then `copy_fut` will be automatically
     // dropped, or vice vera.
     let combined_fut = async move {
-        cmd_fut.join(worker_fut).compat().await?;
+        cmd_fut.compat().join(worker_fut).compat().await?;
         let result: Result<()> = Ok(());
         result
     };

--- a/dbcrossbarlib/src/drivers/bigquery/local_data.rs
+++ b/dbcrossbarlib/src/drivers/bigquery/local_data.rs
@@ -27,7 +27,6 @@ pub(crate) async fn local_data_helper(
             temporary_storage.clone(),
             IfExists::Overwrite,
         )
-        .compat()
         .await?;
 
     // Copy from a temporary gs:// location.
@@ -39,6 +38,5 @@ pub(crate) async fn local_data_helper(
             Query::default(),
             temporary_storage.clone(),
         )
-        .compat()
         .await?)
 }

--- a/dbcrossbarlib/src/drivers/bigquery/mod.rs
+++ b/dbcrossbarlib/src/drivers/bigquery/mod.rs
@@ -98,9 +98,7 @@ impl Locator for BigQueryLocator {
         query: Query,
         temporary_storage: TemporaryStorage,
     ) -> BoxFuture<Option<BoxStream<CsvStream>>> {
-        local_data_helper(ctx, self.clone(), schema, query, temporary_storage)
-            .boxed()
-            .compat()
+        local_data_helper(ctx, self.clone(), schema, query, temporary_storage).boxed()
     }
 
     fn write_local_data(
@@ -120,7 +118,6 @@ impl Locator for BigQueryLocator {
             if_exists,
         )
         .boxed()
-        .compat()
     }
 
     fn supports_write_remote_data(&self, source: &dyn Locator) -> bool {
@@ -146,7 +143,6 @@ impl Locator for BigQueryLocator {
             if_exists,
         )
         .boxed()
-        .compat()
     }
 }
 

--- a/dbcrossbarlib/src/drivers/bigquery/write_local_data.rs
+++ b/dbcrossbarlib/src/drivers/bigquery/write_local_data.rs
@@ -30,20 +30,10 @@ pub(crate) async fn write_local_data_helper(
 
     // Wait for all gs:// uploads to finish with controllable parallelism.
     //
-    // TODO: This duplicates our top-level `cp` code and we need to implement the
-    // same rules for picking a good argument to `buffered` and not just hard code
-    // our parallelism.
-    result_stream
-        // This stream contains std futures, but we need tokio futures for
-        // `buffered`.
-        .map(|fut: BoxFuture<()>| fut.compat())
-        .buffered(4)
-        .collect()
-        .compat()
-        // This `boxed` is needed to prevent weird lifetime issues from
-        // seeping into the type of this function.
-        .boxed()
-        .await?;
+    // TODO: This duplicates our top-level `cp` code and we need to implement
+    // the same rules for picking a good argument to `consume_with_parallelism`
+    // and not just hard code our parallelism.
+    result_stream.consume_with_parallelism(4).await?;
 
     // Load from gs:// to BigQuery.
     let from_temp_ctx = ctx.child(o!("from_temp" => gs_temp.to_string()));

--- a/dbcrossbarlib/src/drivers/bigquery/write_local_data.rs
+++ b/dbcrossbarlib/src/drivers/bigquery/write_local_data.rs
@@ -3,6 +3,7 @@
 use super::find_gs_temp_dir;
 use crate::common::*;
 use crate::drivers::bigquery::BigQueryLocator;
+use crate::tokio_glue::ConsumeWithParallelism;
 
 /// Implementation of `write_local_data`, but as a real `async` function.
 pub(crate) async fn write_local_data_helper(

--- a/dbcrossbarlib/src/drivers/csv/mod.rs
+++ b/dbcrossbarlib/src/drivers/csv/mod.rs
@@ -80,9 +80,7 @@ impl Locator for CsvLocator {
         query: Query,
         _temporary_storage: TemporaryStorage,
     ) -> BoxFuture<Option<BoxStream<CsvStream>>> {
-        local_data_helper(ctx, self.path.clone(), query)
-            .boxed()
-            .compat()
+        local_data_helper(ctx, self.path.clone(), query).boxed()
     }
 
     fn write_local_data(
@@ -95,7 +93,6 @@ impl Locator for CsvLocator {
     ) -> BoxFuture<BoxStream<BoxFuture<()>>> {
         write_local_data_helper(ctx, self.path.clone(), schema, data, if_exists)
             .boxed()
-            .compat()
     }
 }
 
@@ -184,7 +181,7 @@ async fn write_local_data_helper(
                         |_| format!("error writing {}", csv_path.display()),
                     )?;
                     Ok(())
-                }.boxed().compat()
+                }.boxed()
             });
             Ok(Box::new(result_stream) as BoxStream<BoxFuture<()>>)
         }

--- a/dbcrossbarlib/src/drivers/gs/local_data.rs
+++ b/dbcrossbarlib/src/drivers/gs/local_data.rs
@@ -43,7 +43,7 @@ pub(crate) async fn local_data_helper(
     // in case there are a lot of CSV files we need to read.
     let file_urls = io::lines(BufReader::with_capacity(BUFFER_SIZE, child_stdout))
         .map_err(|e| format_err!("error reading gsutil output: {}", e));
-    let csv_streams = file_urls.and_then(move |file_url| -> BoxFuture<CsvStream> {
+    let csv_streams = file_urls.and_then(move |file_url| {
         let ctx = ctx.clone();
         let url = url.clone();
         async move {

--- a/dbcrossbarlib/src/drivers/gs/mod.rs
+++ b/dbcrossbarlib/src/drivers/gs/mod.rs
@@ -69,9 +69,7 @@ impl Locator for GsLocator {
         query: Query,
         _temporary_storage: TemporaryStorage,
     ) -> BoxFuture<Option<BoxStream<CsvStream>>> {
-        local_data_helper(ctx, self.url.clone(), query)
-            .boxed()
-            .compat()
+        local_data_helper(ctx, self.url.clone(), query).boxed()
     }
 
     fn write_local_data(
@@ -82,9 +80,7 @@ impl Locator for GsLocator {
         _temporary_storage: TemporaryStorage,
         if_exists: IfExists,
     ) -> BoxFuture<BoxStream<BoxFuture<()>>> {
-        write_local_data_helper(ctx, self.url.clone(), schema, data, if_exists)
-            .boxed()
-            .compat()
+        write_local_data_helper(ctx, self.url.clone(), schema, data, if_exists).boxed()
     }
 
     fn supports_write_remote_data(&self, source: &dyn Locator) -> bool {
@@ -110,6 +106,5 @@ impl Locator for GsLocator {
             if_exists,
         )
         .boxed()
-        .compat()
     }
 }

--- a/dbcrossbarlib/src/drivers/gs/write_local_data.rs
+++ b/dbcrossbarlib/src/drivers/gs/write_local_data.rs
@@ -53,7 +53,6 @@ pub(crate) async fn write_local_data_helper(
             }
         }
             .boxed()
-            .compat()
     });
 
     Ok(Box::new(written) as BoxStream<BoxFuture<()>>)

--- a/dbcrossbarlib/src/drivers/postgres/mod.rs
+++ b/dbcrossbarlib/src/drivers/postgres/mod.rs
@@ -147,7 +147,6 @@ impl Locator for PostgresLocator {
             query,
         )
         .boxed()
-        .compat()
     }
 
     fn write_local_data(
@@ -167,6 +166,5 @@ impl Locator for PostgresLocator {
             if_exists,
         )
         .boxed()
-        .compat()
     }
 }

--- a/dbcrossbarlib/src/drivers/postgres/write_local_data.rs
+++ b/dbcrossbarlib/src/drivers/postgres/write_local_data.rs
@@ -201,5 +201,5 @@ pub(crate) async fn write_local_data_helper(
             }
         }
     };
-    Ok(box_stream_once(Ok(fut.boxed().compat())))
+    Ok(box_stream_once(Ok(fut.boxed())))
 }

--- a/dbcrossbarlib/src/drivers/s3/local_data.rs
+++ b/dbcrossbarlib/src/drivers/s3/local_data.rs
@@ -40,7 +40,7 @@ pub(crate) async fn local_data_helper(
     // switching from `aws s3` to native S3 API calls from Rust.
     let lines = io::lines(BufReader::with_capacity(BUFFER_SIZE, child_stdout))
         .map_err(|e| format_err!("error reading `aws s3 ls` output: {}", e));
-    let csv_streams = lines.and_then(move |line| -> BoxFuture<CsvStream> {
+    let csv_streams = lines.and_then(move |line| {
         let ctx = ctx.clone();
         let url = url.clone();
         async move {

--- a/dbcrossbarlib/src/drivers/s3/mod.rs
+++ b/dbcrossbarlib/src/drivers/s3/mod.rs
@@ -59,9 +59,7 @@ impl Locator for S3Locator {
         query: Query,
         _temporary_storage: TemporaryStorage,
     ) -> BoxFuture<Option<BoxStream<CsvStream>>> {
-        local_data_helper(ctx, self.url.clone(), query)
-            .boxed()
-            .compat()
+        local_data_helper(ctx, self.url.clone(), query).boxed()
     }
 
     fn write_local_data(
@@ -72,8 +70,6 @@ impl Locator for S3Locator {
         _temporary_storage: TemporaryStorage,
         if_exists: IfExists,
     ) -> BoxFuture<BoxStream<BoxFuture<()>>> {
-        write_local_data_helper(ctx, self.url.clone(), schema, data, if_exists)
-            .boxed()
-            .compat()
+        write_local_data_helper(ctx, self.url.clone(), schema, data, if_exists).boxed()
     }
 }

--- a/dbcrossbarlib/src/drivers/s3/write_local_data.rs
+++ b/dbcrossbarlib/src/drivers/s3/write_local_data.rs
@@ -53,7 +53,6 @@ pub(crate) async fn write_local_data_helper(
             }
         }
             .boxed()
-            .compat()
     });
 
     Ok(Box::new(written) as BoxStream<BoxFuture<()>>)

--- a/dbcrossbarlib/src/lib.rs
+++ b/dbcrossbarlib/src/lib.rs
@@ -72,7 +72,7 @@ pub(crate) mod common {
         query::Query,
         schema::Table,
         temporary_storage::TemporaryStorage,
-        tokio_glue::{box_stream_once, BoxFuture, BoxStream, ConsumeWithParallelism},
+        tokio_glue::{box_stream_once, BoxFuture, BoxStream},
         Error, Result, BUFFER_SIZE,
     };
 }

--- a/dbcrossbarlib/src/lib.rs
+++ b/dbcrossbarlib/src/lib.rs
@@ -44,6 +44,7 @@ pub use if_exists::IfExists;
 pub use locator::{BoxLocator, Locator};
 pub use query::Query;
 pub use temporary_storage::TemporaryStorage;
+pub use tokio_glue::ConsumeWithParallelism;
 
 /// Definitions included by all the files in this crate.
 ///
@@ -71,7 +72,7 @@ pub(crate) mod common {
         query::Query,
         schema::Table,
         temporary_storage::TemporaryStorage,
-        tokio_glue::{box_stream_once, BoxFuture, BoxStream},
+        tokio_glue::{box_stream_once, BoxFuture, BoxStream, ConsumeWithParallelism},
         Error, Result, BUFFER_SIZE,
     };
 }

--- a/dbcrossbarlib/src/locator.rs
+++ b/dbcrossbarlib/src/locator.rs
@@ -74,7 +74,7 @@ pub trait Locator: fmt::Debug + fmt::Display + Send + Sync + 'static {
         _temporary_storage: TemporaryStorage,
     ) -> BoxFuture<Option<BoxStream<CsvStream>>> {
         // Turn our result into a future.
-        async { Ok(None) }.boxed().compat()
+        async { Ok(None) }.boxed()
     }
 
     /// If this locator can be used as a local data sink, write data to it.
@@ -106,7 +106,7 @@ pub trait Locator: fmt::Debug + fmt::Display + Send + Sync + 'static {
         _if_exists: IfExists,
     ) -> BoxFuture<BoxStream<BoxFuture<()>>> {
         let err = format_err!("cannot write data to {}", self);
-        async move { Err(err) }.boxed().compat()
+        async move { Err(err) }.boxed()
     }
 
     /// Can we access the data at `source` directly using `write_remote_data`?
@@ -128,7 +128,7 @@ pub trait Locator: fmt::Debug + fmt::Display + Send + Sync + 'static {
         _if_exists: IfExists,
     ) -> BoxFuture<()> {
         let err = format_err!("cannot write_remote_data from source {}", source);
-        async move { Err(err) }.boxed().compat()
+        async move { Err(err) }.boxed()
     }
 }
 

--- a/dbcrossbarlib/src/tokio_glue.rs
+++ b/dbcrossbarlib/src/tokio_glue.rs
@@ -3,18 +3,17 @@
 //! This is mostly smaller things that happen to recur in our particular
 //! application.
 
-use futures::compat::Compat as Compat03As01;
 use std::{cmp::min, future::Future as StdFuture, pin::Pin, thread};
 use tokio::io;
 
 use crate::common::*;
 
-/// Standard future type for this library. Like `Result`, but used by async.
-/// This is a bit tricky, because we want it to be a `tokio` future, but to do
-/// that, we need to box it, mark it as pinned, and _then_ apply a compatibility
-/// wrapper.
-pub type BoxFuture<T> =
-    Compat03As01<Pin<Box<dyn StdFuture<Output = Result<T>> + Send>>>;
+/// Standard future type for this library. Like `Result`, but used by async. We
+/// mark it as `Send` to ensure it can be sent between threads safely (even when
+/// blocked on `.await`!), and we `Pin<Box<...>>` it using `.boxed()` to make it
+/// an abstract, heap-based type, for convenience. All we know is that it will
+/// return a `Result<T>`.
+pub type BoxFuture<T> = Pin<Box<dyn StdFuture<Output = Result<T>> + Send + 'static>>;
 
 /// A stream of values of type `T`, using our standard error type, and imposing
 /// enough restrictions to be able send streams between threads.


### PR DESCRIPTION
Our core future type is `BoxFuture<T>`, which is currently a
`tokio`-compatible future. This patch converts it to a
`std::future::Future` by removing that wrapper. This involves a
converting a lot of `.boxed().compat()` to `.boxed()`, and inserting the
`.compat()` calls in other places.

This means that we're getting ever-closer to a world where we use
`std::future::Future` everywhere. We're just waiting for `tokio` and the
surrounding ecosystem to make the jump, which may take a while. And for
`.await` to stablize.