### PR TITLE
Add `--log-format=json` option (also `flat`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,6 +403,7 @@ dependencies = [
  "slog 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-envlogger 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog-json 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-term 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt-derive 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1536,6 +1537,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "slog-json"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "slog-scope"
 version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2354,6 +2366,7 @@ dependencies = [
 "checksum slog 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "36d9e85f8df625a6ac087188d0826546df56e07190bede661c10c95a95890cad"
 "checksum slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e544d16c6b230d84c866662fe55e31aacfca6ae71e6fc49ae9a311cb379bfc2f"
 "checksum slog-envlogger 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f7c6685180086bf58624e92cb3da5d5f013bebd609454926fc8e2ac6345d384b"
+"checksum slog-json 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ddc0d2aff1f8f325ef660d9a0eb6e6dcd20b30b3f581a5897f58bf42d061c37a"
 "checksum slog-scope 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "60c04b4726fa04595ccf2c2dad7bcd15474242c4c5e109a8a376e8a2c9b1539a"
 "checksum slog-stdlog 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ac42f8254ae996cc7d640f9410d3b048dcdf8887a10df4d5d4c44966de24c4a8"
 "checksum slog-term 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cb9b3fd9a3c2c86580fce3558a98ed7c69039da0288b08a3f15b371635254e08"

--- a/dbcrossbar/Cargo.toml
+++ b/dbcrossbar/Cargo.toml
@@ -29,6 +29,7 @@ serde_json = "1.0.32"
 slog = { version = "2.4.1", features = ["max_level_trace", "release_max_level_trace"] }
 slog-async = "2.3.0"
 slog-envlogger = "2.1.0"
+slog-json = "2.3.0"
 slog-term = "2.4.0"
 structopt = "0.2.10"
 structopt-derive = "0.2.14"

--- a/dbcrossbar/src/cmd/mod.rs
+++ b/dbcrossbar/src/cmd/mod.rs
@@ -5,6 +5,8 @@ use futures::FutureExt;
 //use structopt::StructOpt;
 use structopt_derive::StructOpt;
 
+use crate::logging::LogFormat;
+
 pub(crate) mod conv;
 pub(crate) mod cp;
 
@@ -14,7 +16,19 @@ pub(crate) mod cp;
     name = "dbcrossbar",
     about = "Convert schemas and data between databases."
 )]
-pub(crate) enum Opt {
+pub(crate) struct Opt {
+    /// Logging format (indented, flat, json).
+    #[structopt(long = "log-format", default_value = "indented")]
+    pub(crate) log_format: LogFormat,
+
+    /// The command to run.
+    #[structopt(subcommand)]
+    pub(crate) cmd: Command,
+}
+
+/// The command to run.
+#[derive(Debug, StructOpt)]
+pub(crate) enum Command {
     #[structopt(name = "conv")]
     #[structopt(after_help = r#"EXAMPLE LOCATORS:
     postgres-sql:table.sql
@@ -38,8 +52,8 @@ pub(crate) enum Opt {
 }
 
 pub(crate) fn run(ctx: Context, opt: Opt) -> BoxFuture<()> {
-    match opt {
-        Opt::Conv { command } => conv::run(ctx, command).boxed(),
-        Opt::Cp { command } => cp::run(ctx, command).boxed(),
+    match opt.cmd {
+        Command::Conv { command } => conv::run(ctx, command).boxed(),
+        Command::Cp { command } => cp::run(ctx, command).boxed(),
     }
 }

--- a/dbcrossbar/src/cmd/mod.rs
+++ b/dbcrossbar/src/cmd/mod.rs
@@ -21,6 +21,10 @@ pub(crate) struct Opt {
     #[structopt(long = "log-format", default_value = "indented")]
     pub(crate) log_format: LogFormat,
 
+    /// A `key=value` pair to add to our logs. May be passed multiple times.
+    #[structopt(long = "log-extra")]
+    pub(crate) log_extra: Vec<String>,
+
     /// The command to run.
     #[structopt(subcommand)]
     pub(crate) cmd: Command,

--- a/dbcrossbar/src/logging.rs
+++ b/dbcrossbar/src/logging.rs
@@ -1,0 +1,57 @@
+//! Support for structured logging.
+
+use dbcrossbarlib::Error;
+use failure::format_err;
+use slog::{Drain, Never};
+use slog_json;
+use slog_term;
+use std::{io::stderr, str::FromStr};
+
+/// A polymorphic log drain (which means we need to use `Box<dyn ...>`,
+/// because that's how Rust does runtime polymorphism).
+type BoxDrain = Box<dyn Drain<Ok = (), Err = Never> + Send + 'static>;
+
+/// What log format we should use.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub(crate) enum LogFormat {
+    /// Pretty, indented logs.
+    Indented,
+    /// Single-line log entries with all keys on each line.
+    Flat,
+    /// JSON records.
+    Json,
+}
+
+impl LogFormat {
+    /// Create an appropriate `Drain` for this log format.
+    pub(crate) fn create_drain(self) -> BoxDrain {
+        match self {
+            Self::Indented => {
+                let decorator = slog_term::TermDecorator::new().stderr().build();
+                Box::new(slog_term::CompactFormat::new(decorator).build().fuse())
+                    as BoxDrain
+            }
+            Self::Flat => {
+                let decorator = slog_term::PlainDecorator::new(stderr());
+                Box::new(slog_term::FullFormat::new(decorator).build().fuse())
+                    as BoxDrain
+            }
+            Self::Json => {
+                Box::new(slog_json::Json::default(stderr()).fuse()) as BoxDrain
+            }
+        }
+    }
+}
+
+impl FromStr for LogFormat {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "indented" => Ok(LogFormat::Indented),
+            "flat" => Ok(LogFormat::Flat),
+            "json" => Ok(LogFormat::Json),
+            _ => Err(format_err!("unknown log format: {}", s)),
+        }
+    }
+}

--- a/dbcrossbar/src/logging.rs
+++ b/dbcrossbar/src/logging.rs
@@ -1,11 +1,11 @@
 //! Support for structured logging.
 
-use dbcrossbarlib::Error;
+use dbcrossbarlib::{Error, Result};
 use failure::format_err;
-use slog::{Drain, Never};
+use slog::{error, slog_o as o, Drain, Logger, Never};
 use slog_json;
 use slog_term;
-use std::{io::stderr, str::FromStr};
+use std::{io::stderr, result, str::FromStr, sync::Arc};
 
 /// A polymorphic log drain (which means we need to use `Box<dyn ...>`,
 /// because that's how Rust does runtime polymorphism).
@@ -46,7 +46,7 @@ impl LogFormat {
 impl FromStr for LogFormat {
     type Err = Error;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> result::Result<Self, Self::Err> {
         match s {
             "indented" => Ok(LogFormat::Indented),
             "flat" => Ok(LogFormat::Flat),
@@ -54,4 +54,49 @@ impl FromStr for LogFormat {
             _ => Err(format_err!("unknown log format: {}", s)),
         }
     }
+}
+
+/// Given a log `drain`, and a list of `extra` values in the format
+/// `"key=value"`, create a global logger.
+pub(crate) fn global_logger_with_extra_values(
+    drain: slog::Fuse<slog_async::Async>,
+    extra: &[String],
+) -> Result<Logger> {
+    // Construct our base logger.
+    let values = o!(
+        "app" => env!("CARGO_PKG_NAME"),
+        "ver" => env!("CARGO_PKG_VERSION"),
+    );
+    let mut log = Logger::root(drain, values);
+
+    // If we have `log_extra` values, add them to our logger. This is much
+    // trickier than you think, because the `o!` macro doesn't return a normal
+    // hash-map, but instead a highly-optimized type that can't be mutated, and
+    // which has a different compile-time type for different numbers of keys. So
+    // the only way to build up a variable-length set of key-value pairs is to
+    // use `log.new` and construct a chain of loggers, _each_ with a single
+    // key-value pair.
+    for kv_str in extra {
+        let kv = kv_str.splitn(2, '=').collect::<Vec<_>>();
+        if kv.len() != 2 {
+            let err =
+                format_err!("expected {:?} to contain a \"=\" character", kv_str);
+            error!(log, "{}", err);
+            return Err(err);
+        }
+
+        // YUCK. The `o!` macro requires a `&'static str` as a key. We can only
+        // create one of these by putting a `String` into a `Box` and using
+        // `Box::leak` to permanently leak the `Box<String>` for the rest of the
+        // program's lifetime. This is an ugly Rust trick that almost always
+        // means we're doing something _horribly_ wrong and we should stop
+        // immediately, but in this case we have no other choice, given the
+        // `slog` API. Happily, this is a global logger, so this shouldn't
+        // normally happen.
+        let key = &Box::leak::<'static>(Box::new(kv[0].to_owned()))[..];
+        let value = kv[1].to_owned();
+        log = log.new(o!(key => value));
+    }
+
+    Ok(log)
 }

--- a/dbcrossbar/src/logging.rs
+++ b/dbcrossbar/src/logging.rs
@@ -5,7 +5,7 @@ use failure::format_err;
 use slog::{error, slog_o as o, Drain, Logger, Never};
 use slog_json;
 use slog_term;
-use std::{io::stderr, result, str::FromStr, sync::Arc};
+use std::{io::stderr, result, str::FromStr};
 
 /// A polymorphic log drain (which means we need to use `Box<dyn ...>`,
 /// because that's how Rust does runtime polymorphism).

--- a/dbcrossbar/src/main.rs
+++ b/dbcrossbar/src/main.rs
@@ -51,13 +51,7 @@ fn run() -> Result<()> {
         .overflow_strategy(OverflowStrategy::Block)
         .build()
         .fuse();
-    let log = Logger::root(
-        drain,
-        slog_o!(
-            "app" => env!("CARGO_PKG_NAME"),
-            "ver" => env!("CARGO_PKG_VERSION"),
-        ),
-    );
+    let log = logging::global_logger_with_extra_values(drain, &opt.log_extra)?;
 
     // Set up an execution context for our background workers, if any. The `ctx`
     // must be passed to all our background operations. The `worker_fut` will

--- a/dbcrossbar/src/main.rs
+++ b/dbcrossbar/src/main.rs
@@ -17,7 +17,7 @@ use dbcrossbarlib::Context;
 use env_logger;
 use futures::{compat::Future01CompatExt, FutureExt, TryFutureExt};
 use openssl_probe;
-use slog::{debug, slog_o, Drain, Logger};
+use slog::{debug, Drain};
 use slog_async::{self, OverflowStrategy};
 use slog_envlogger;
 use structopt::{self, StructOpt};


### PR DESCRIPTION
We now support the following structured logging output formats:

- `--log-format=indented`: Pretty, colorized, indented logs, suitable for easy visual scanning.
- `--log-format=flat`: Flat, un-colorized logs, suitable for textual log databases that centralize logs for multiple applications and servers.
- `--log-format=json`: Pure JSON logs, for structured logging systems.

We also add a `--log-extra=key=value`, which allows injecting one or more extra key-value pairs into our logs.

Passing `--log-format=json --log-extra=batch_id=123abc` yields single-line JSON log records that look like:

    {
      "msg": "...log message here...",
      "level": "DEBG",
      "ts": "2019-07-24T03:22:21.278078276-04:00",
      "batch_id": "123abc",
      "ver": "0.2.0-alpha.6",
      "app": "dbcrossbar"
    }

The `msg`, `level` and `ts` fields are generated by the `slog` library; the rest we add ourselves.

@n1ywb I'm going to go ahead and merge this PR so that I can build new binaries, but I would still appreciate a code review when you have a moment.