### PR TITLE
BigQuery: Only allow upsert on REQUIRED columns (fixes #43)

### DIFF
--- a/dbcrossbar/fixtures/upsert.sql
+++ b/dbcrossbar/fixtures/upsert.sql
@@ -1,6 +1,6 @@
 CREATE TABLE upsert_test (
-    key1 INT,
-    key2 INT,
+    key1 INT NOT NULL,
+    key2 INT NOT NULL,
     value TEXT,
     more TEXT[]
 );

--- a/dbcrossbarlib/src/drivers/bigquery_shared/column.rs
+++ b/dbcrossbarlib/src/drivers/bigquery_shared/column.rs
@@ -40,7 +40,7 @@ pub(crate) struct BqColumn {
     /// This can be omitted in certain output from `bq show --schema`, in which
     /// case it appears to correspond to `NULLABLE`.
     #[serde(default)]
-    mode: Mode,
+    pub(crate) mode: Mode,
 }
 
 impl BqColumn {

--- a/dbcrossbarlib/src/drivers/bigquery_shared/table.rs
+++ b/dbcrossbarlib/src/drivers/bigquery_shared/table.rs
@@ -7,7 +7,7 @@ use std::{
     io::Write,
 };
 
-use super::{BqColumn, ColumnBigQueryExt, Ident, TableName, Usage};
+use super::{BqColumn, ColumnBigQueryExt, Ident, Mode, TableName, Usage};
 use crate::common::*;
 use crate::schema::{Column, Table};
 
@@ -128,6 +128,18 @@ impl BqTable {
                 })?)
             })
             .collect::<Result<Vec<&BqColumn>>>()?;
+
+        // As discussed at https://github.com/faradayio/dbcrossbar/issues/43,
+        // it's not obvious how to `MERGE` on columns that might be `NULL`.
+        // Until we have a solution that we like, fail with an error.
+        for merge_key in &merge_keys {
+            if merge_key.mode != Mode::Required {
+                return Err(format_err!(
+                    "BigQuery cannot upsert on {:?} because it is not REQUIRED (aka NOT NULL)",
+                    merge_key.name,
+                ));
+            }
+        }
 
         // Build a table when we can check for merge keys by name.
         let merge_key_table = merge_keys


### PR DESCRIPTION
It turns out that upsert and `NULL` do not play nicely
together. BigQuery joins support neither `IS NOT DISTINCT FROM` nor
compound tests using `IS NOT NULL`. So the best decision here is to only
allow joins on columns which are known to be `REQUIRED` (which maps to
`NOT NULL` columns using SQL table definitions).