### PR TITLE
Pass correct flag to append to BigQuery (fixes #36)

### DIFF
--- a/dbcrossbarlib/src/drivers/bigquery/write_remote_data.rs
+++ b/dbcrossbarlib/src/drivers/bigquery/write_remote_data.rs
@@ -182,7 +182,7 @@ pub(crate) async fn write_remote_data_helper(
         }
         debug!(ctx.log(), "import sql: {}", String::from_utf8_lossy(&query));
 
-        // Pipe our query text to `bq load`.
+        // Pipe our query text to `bq query`.
         debug!(ctx.log(), "running `bq query`");
         let mut query_command = Command::new("bq");
         query_command
@@ -209,13 +209,13 @@ pub(crate) async fn write_remote_data_helper(
         io::write_all(child_stdin, query)
             .compat()
             .await
-            .context("error piping query to `bq load`")?;
+            .context("error piping query to `bq query`")?;
         let status = query_child
             .compat()
             .await
             .context("error running `bq query`")?;
         if !status.success() {
-            return Err(format_err!("`bq load` failed with {}", status));
+            return Err(format_err!("`bq query` failed with {}", status));
         }
 
         // Delete temp table.

--- a/dbcrossbarlib/src/drivers/gs/write_remote_data.rs
+++ b/dbcrossbarlib/src/drivers/gs/write_remote_data.rs
@@ -84,13 +84,13 @@ pub(crate) async fn write_remote_data_helper(
     io::write_all(child_stdin, export_sql)
         .compat()
         .await
-        .context("error piping query to `bq load`")?;
+        .context("error piping query to `bq query`")?;
     let status = query_child
         .compat()
         .await
         .context("error running `bq query`")?;
     if !status.success() {
-        return Err(format_err!("`bq load` failed with {}", status));
+        return Err(format_err!("`bq query` failed with {}", status));
     }
 
     // Delete the existing output, if it exists.


### PR DESCRIPTION
When appending, we should do `--append_table` not `--noreplace`

Tested manually.