### PR TITLE
Replace dashes with underscores when copying to BigQuery - fixes #50

### DIFF
--- a/dbcrossbarlib/src/drivers/bigquery_shared/column.rs
+++ b/dbcrossbarlib/src/drivers/bigquery_shared/column.rs
@@ -46,6 +46,8 @@ pub(crate) struct BqColumn {
 impl BqColumn {
     /// Given a portable `Column`, and an intended usage, return a corresponding
     /// `BqColumn`.
+    ///
+    /// Note that dashes are replaced with underscores to satisfy BigQuery naming rules.
     pub(crate) fn for_column(col: &Column, usage: Usage) -> Result<BqColumn> {
         let bq_data_type = BqDataType::for_data_type(&col.data_type, usage)?;
         let (ty, mode): (BqNonArrayDataType, Mode) = match bq_data_type {
@@ -56,7 +58,7 @@ impl BqColumn {
             BqDataType::NonArray(ty) => (ty, Mode::Required),
         };
         Ok(BqColumn {
-            name: col.name.to_owned(),
+            name: col.name.replace('-', &'_'.to_string()).to_owned(),
             description: None,
             ty,
             mode,


### PR DESCRIPTION
This is a very limited fix to a common problem. It's a one-way fix, in the sense that once it "fixes" dashes there's no way to get them back.