### PR TITLE
Add `--stream-size` parameter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,6 +446,7 @@ dependencies = [
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humanize-rs 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -868,6 +869,11 @@ dependencies = [
 [[package]]
 name = "httparse"
 version = "1.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "humanize-rs"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2681,6 +2687,7 @@ dependencies = [
 "checksum http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "372bcb56f939e449117fb0869c2e8fd8753a8223d92a172c6e808cf123a5b6e4"
 "checksum http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
+"checksum humanize-rs 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "016b02deb8b0c415d8d56a6f0ab265e50c22df61194e37f9be75ed3a722de8a6"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum hyper 0.12.34 (registry+https://github.com/rust-lang/crates.io-index)" = "898a87371a3999b2f731b9af636cd76aa20de10e69c2daf3e71388326b619fe0"
 "checksum hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"

--- a/dbcrossbar/Cargo.toml
+++ b/dbcrossbar/Cargo.toml
@@ -20,6 +20,7 @@ common_failures = "0.1.1"
 env_logger = "0.6"
 failure = "0.1.2"
 futures-preview = { version = "0.3.0-alpha.17", features = ["compat"] }
+humanize-rs = "0.1.5"
 log = "0.4.5"
 openssl = "0.10.16" # Needed to prevent link errors.
 openssl-probe = "0.1.2"

--- a/dbcrossbar/src/cmd/cp.rs
+++ b/dbcrossbar/src/cmd/cp.rs
@@ -2,12 +2,14 @@
 
 use common_failures::Result;
 use dbcrossbarlib::{
+    rechunk::rechunk_csvs,
     tokio_glue::{BoxFuture, BoxStream},
     BoxLocator, Context, DestinationArguments, DisplayOutputLocators, DriverArguments,
     IfExists, SharedArguments, SourceArguments, TemporaryStorage,
 };
 use failure::format_err;
 use futures::{compat::Future01CompatExt, FutureExt, TryFutureExt};
+use humanize_rs::bytes::Bytes as HumanizedBytes;
 use slog::{debug, o};
 use structopt::{self, StructOpt};
 use tokio::{
@@ -31,6 +33,13 @@ pub(crate) struct Opt {
     /// transfer (can be repeated).
     #[structopt(long = "temporary")]
     temporaries: Vec<String>,
+
+    /// Specify the approximate size of the CSV streams manipulated by
+    /// `dbcrossbar`. This can be used to split a large input into multiple
+    /// smaller outputs. Actual data streams may be bigger or smaller depending
+    /// on a number of factors. Examples: "100000", "1Gb".
+    #[structopt(long = "stream-size")]
+    stream_size: Option<HumanizedBytes>, // usize
 
     /// Pass an extra argument of the form `key=value` to the source driver.
     #[structopt(long = "from-arg")]
@@ -83,7 +92,9 @@ pub(crate) async fn run(ctx: Context, opt: Opt) -> Result<()> {
     // local machine?
     let to_locator = opt.to_locator;
     let from_locator = opt.from_locator;
-    let dests = if to_locator.supports_write_remote_data(from_locator.as_ref()) {
+    let should_use_remote = opt.stream_size.is_none()
+        && to_locator.supports_write_remote_data(from_locator.as_ref());
+    let dests = if should_use_remote {
         // Build a logging context.
         let ctx = ctx.child(o!(
             "from_locator" => from_locator.to_string(),
@@ -104,12 +115,18 @@ pub(crate) async fn run(ctx: Context, opt: Opt) -> Result<()> {
         debug!(ctx.log(), "performing local data transfer");
 
         let input_ctx = ctx.child(o!("from_locator" => from_locator.to_string()));
-        let data = from_locator
+        let mut data = from_locator
             .local_data(input_ctx, shared_args.clone(), source_args)
             .await?
             .ok_or_else(|| {
                 format_err!("don't know how to read data from {}", from_locator)
             })?;
+
+        // Honor --chunck-size if passed.
+        if let Some(stream_size) = opt.stream_size {
+            let stream_size = stream_size.size();
+            data = rechunk_csvs(ctx.clone(), stream_size, data)?;
+        }
 
         // Write data to output.
         let output_ctx = ctx.child(o!("to_locator" => to_locator.to_string()));

--- a/dbcrossbar/src/cmd/cp.rs
+++ b/dbcrossbar/src/cmd/cp.rs
@@ -122,7 +122,7 @@ pub(crate) async fn run(ctx: Context, opt: Opt) -> Result<()> {
                 format_err!("don't know how to read data from {}", from_locator)
             })?;
 
-        // Honor --chunck-size if passed.
+        // Honor --stream-size if passed.
         if let Some(stream_size) = opt.stream_size {
             let stream_size = stream_size.size();
             data = rechunk_csvs(ctx.clone(), stream_size, data)?;

--- a/dbcrossbarlib/src/concat.rs
+++ b/dbcrossbarlib/src/concat.rs
@@ -64,8 +64,6 @@ pub(crate) fn concatenate_csv_streams(
 
 #[test]
 fn concatenate_csv_streams_strips_all_but_first_header() {
-    use tokio::sync::mpsc;
-
     let input_1 = b"a,b\n1,2\n";
     let input_2 = b"a,b\n3,4\n";
     let expected = b"a,b\n1,2\n3,4\n";
@@ -73,7 +71,7 @@ fn concatenate_csv_streams_strips_all_but_first_header() {
     let (ctx, worker_fut) = Context::create_for_test("concatenate_csv_streams");
 
     let cmd_fut = async move {
-        debug!(ctx.log(), "testing");
+        debug!(ctx.log(), "testing concatenate_csv_streams");
 
         // Build our `BoxStream<CsvStream>`.
         let (mut sender, receiver) = mpsc::channel(2);

--- a/dbcrossbarlib/src/lib.rs
+++ b/dbcrossbarlib/src/lib.rs
@@ -25,6 +25,7 @@ pub(crate) mod from_json_value;
 pub(crate) mod if_exists;
 pub(crate) mod locator;
 pub(crate) mod path_or_stdio;
+pub mod rechunk;
 pub mod schema;
 pub(crate) mod separator;
 mod temporary_storage;

--- a/dbcrossbarlib/src/rechunk.rs
+++ b/dbcrossbarlib/src/rechunk.rs
@@ -40,7 +40,7 @@ pub fn rechunk_csvs(
             .context("cannot read chunk header")?
             .to_owned();
 
-        /// A single output chunk.
+        /// A single output chunk. The state we need to generate a single `CsvStream`.
         struct Chunk<W: Write> {
             /// Write to this to add data to the chunk.
             wtr: csv::Writer<W>,
@@ -57,8 +57,8 @@ pub fn rechunk_csvs(
         // `CsvStream`s.
         let mut chunk_id: usize = 0;
 
-        // Construct a new `CsvStream`, send to our ultimate consumer, and
-        // return a synchronous `csv::Writer` which can be used to write data to
+        // Construct a new `CsvStream`, and
+        // return a `Chunk` with a `csv::Writer` which can be used to write data to
         // it.
         let mut new_chunk = || -> Result<Chunk<_>> {
             chunk_id = chunk_id.checked_add(1).expect("too many chunks");

--- a/dbcrossbarlib/src/rechunk.rs
+++ b/dbcrossbarlib/src/rechunk.rs
@@ -1,0 +1,237 @@
+//! Given a stream of streams CSV data, rechunk the stream sizes.
+
+use csv;
+use std::{cell::Cell, cmp::min, io, rc::Rc};
+use tokio::sync::mpsc;
+
+use crate::common::*;
+use crate::concat::concatenate_csv_streams;
+use crate::tokio_glue::{SyncStreamReader, SyncStreamWriter};
+
+/// Max buffer size for `csv::Writer`.
+const MAX_CSV_BUFFER_SIZE: usize = 8 * (1 << 10);
+
+/// Given a stream of streams CSV data, return another stream of CSV streams
+/// where the CSV data is approximately `chunk_size` long whenever possible.
+pub fn rechunk_csvs(
+    ctx: Context,
+    chunk_size: usize,
+    streams: BoxStream<CsvStream>,
+) -> Result<BoxStream<CsvStream>> {
+    // Convert out input `BoxStream<CsvStream>` into a single, concatenated
+    // synchronous `Read` object.
+    let ctx = ctx.child(o!("streams_transform" => "rechunk_csvs"));
+    let input_csv_stream = concatenate_csv_streams(ctx.clone(), streams)?;
+    let csv_rdr = SyncStreamReader::new(ctx.clone(), input_csv_stream.data);
+
+    // Create a channel to which we can write `CsvStream` values once we've
+    // created them.
+    let (mut csv_stream_sender, csv_stream_receiver) =
+        mpsc::channel::<Result<CsvStream>>(1);
+
+    // Run a synchronous background worker thread that parsers our sync CSV
+    // `Read`er into a stream of `CsvStream`s.
+    let name = "rechunk".to_owned();
+    let worker_ctx = ctx.clone();
+    let worker_fut = run_sync_fn_in_background(name, move || -> Result<()> {
+        let mut rdr = csv::Reader::from_reader(csv_rdr);
+        let hdr = rdr
+            .byte_headers()
+            .context("cannot read chunk header")?
+            .to_owned();
+
+        /// A single output chunk.
+        struct Chunk<W: Write> {
+            /// Write to this to add data to the chunk.
+            wtr: csv::Writer<W>,
+            /// Approximately how much data have we written, not counting the
+            /// buffer in `wtr`?
+            total_written: Rc<Cell<usize>>,
+            /// The `CsvStream` which will output the data produced by `wtr`.
+            /// Once we publish this vaue to `csv_stream_sender`, we'll set the
+            /// field `csv_stream` to `None`.
+            csv_stream: Option<CsvStream>,
+        }
+
+        // Construct a new `CsvStream`, send to our ultimate consumer, and
+        // return a synchronous `csv::Writer` which can be used to write data to
+        // it.
+        let new_chunk = || -> Result<Chunk<_>> {
+            trace!(worker_ctx.log(), "starting new CSV chunk");
+
+            // Build a `CsvStream` that we can write to synchronously using
+            // `wtr`. Here, `wtr` is a synchronous `Write` implementation,
+            // and `data` is an `impl Stream<Item = BytesMut, ..>`.
+            let (wtr, data) = SyncStreamWriter::pipe(worker_ctx.clone());
+            let csv_stream = CsvStream {
+                name: "chunked".to_owned(), // TODO: Add index.
+                data: Box::new(data),
+            };
+
+            // Keep rough track of how many bytes we've written.
+            let wtr = CountingWriter::new(wtr);
+            let total_written = wtr.total_written();
+
+            // Now, make a `csv::Writer` we can write to. We limit our buffer
+            // size so that `chunk_size` is vaguely accurate.
+            let wtr = csv::WriterBuilder::default()
+                .buffer_capacity(min(MAX_CSV_BUFFER_SIZE, chunk_size))
+                .from_writer(wtr);
+            Ok(Chunk {
+                wtr,
+                total_written,
+                csv_stream: Some(csv_stream),
+            })
+        };
+        let mut chunk = new_chunk()?;
+
+        for row in rdr.byte_records() {
+            let row = row.context("cannot read row")?;
+
+            // If this is the first row we've seen, we can safely send our
+            // `CsvStream` to our `csv_stream_sender: BoxStream<CsvStream>`. We
+            // do this before writing any data, including the headers, so that
+            // somebody hooks up a consumer and prevents `chunk.wtr` from
+            // blocking forever.
+            if let Some(csv_stream) = chunk.csv_stream.take() {
+                csv_stream_sender = csv_stream_sender.send(Ok(csv_stream)).wait()?;
+
+                // Now that we potentially have a consumer, we can safely write our
+                // headers.
+                chunk
+                    .wtr
+                    .write_byte_record(&hdr)
+                    .context("cannot write chunk header")?;
+            }
+
+            // Write our row.
+            chunk
+                .wtr
+                .write_byte_record(&row)
+                .context("cannot write row")?;
+
+            // If total written exceeds chunk size, then start a new chunk.
+            if chunk.total_written.get() >= chunk_size {
+                trace!(worker_ctx.log(), "finishing chunk");
+                chunk = new_chunk()?;
+            }
+        }
+        trace!(worker_ctx.log(), "finished rechunking CSV data");
+        Ok(())
+    });
+    ctx.spawn_worker(worker_fut.boxed().compat());
+
+    // Fix up our `csv_stream_receiver`'s type so it's what what we want.
+    let csv_stream_receiver = csv_stream_receiver
+        // Change `Error` from `mpsc::Error` to our standard `Error`.
+        .map_err(|_| format_err!("stream read error"))
+        // Change `Item` from `Result<CsvStream>` to `CsvStream`, pushing
+        // the error into the stream's `Error` channel instead.
+        .and_then(|result| result);
+
+    let csv_streams = Box::new(csv_stream_receiver) as BoxStream<CsvStream>;
+    Ok(csv_streams)
+}
+
+#[test]
+fn rechunk_csvs_honors_chunk_size() {
+    use std::str;
+
+    let inputs: &[&[u8]] = &[b"a,b\n1,1\n2,1\n", b"a,b\n1,2\n2,2\n"];
+    let expected: &[&[u8]] =
+        &[b"a,b\n1,1\n", b"a,b\n2,1\n", b"a,b\n1,2\n", b"a,b\n2,2\n"];
+
+    let (ctx, worker_fut) = Context::create_for_test("rechunk_csvs");
+
+    let cmd_fut = async move {
+        debug!(ctx.log(), "testing rechunk_csvs");
+
+        // Build our `BoxStream<CsvStream>`.
+        let (mut sender, receiver) = mpsc::channel(2);
+        for &input in inputs {
+            sender = sender
+                .send(CsvStream::from_bytes(input).await)
+                .compat()
+                .await
+                .unwrap();
+        }
+        drop(sender);
+        let csv_streams =
+            Box::new(receiver.map_err(|e| e.into())) as BoxStream<CsvStream>;
+
+        let rechunked_csv_streams = rechunk_csvs(ctx.clone(), 7, csv_streams).unwrap();
+
+        let outputs = rechunked_csv_streams
+            .map(move |csv_stream| {
+                let ctx = ctx.clone();
+                let fut = async move {
+                    let bytes = csv_stream.into_bytes(ctx.clone()).await.unwrap();
+                    trace!(
+                        ctx.log(),
+                        "collected CSV stream: {:?}",
+                        str::from_utf8(&bytes).unwrap()
+                    );
+                    Ok(bytes)
+                };
+                fut.boxed().compat()
+            })
+            .buffered(4)
+            .collect()
+            .compat()
+            .await
+            .unwrap();
+
+        assert_eq!(outputs.len(), expected.len());
+        for (output, &expected) in outputs.into_iter().zip(expected) {
+            assert_eq!(output, expected);
+        }
+
+        Ok(())
+    };
+
+    run_futures_with_runtime(cmd_fut.boxed(), worker_fut).unwrap();
+}
+
+/// A `Write` implementation that keeps track of how much data has been written
+/// so far. Note that if you wrap this in a buffered type like `csv::Writer`, it
+/// won't keep track of the data in `csv::Writer`'s buffer, only the data that
+/// has been flushed.
+struct CountingWriter<W: Write> {
+    /// Our writer.
+    inner: W,
+    /// The total data that we've written. This is wrapped in `Rc<Cell<_>>` so
+    /// that is can be easily accessed from anywhere in the same thread even if
+    /// the `CountingWriter` is completely owned by another type such as
+    /// `csv::Writer`.
+    total_written: Rc<Cell<usize>>,
+}
+
+impl<W: Write> CountingWriter<W> {
+    /// Create a new `CountingWriter` that wraps `inner`.
+    fn new(inner: W) -> Self {
+        Self {
+            inner,
+            total_written: Rc::new(Cell::new(0)),
+        }
+    }
+
+    /// How much data has been written? This returns an `Rc<Cell<_>>` that will
+    /// be updated by this `CountingWriter`. Setting the value in this `Cell`
+    /// directly may result in future reads returning an unspecified value.
+    fn total_written(&self) -> Rc<Cell<usize>> {
+        self.total_written.clone()
+    }
+}
+
+impl<W: Write> Write for CountingWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let written = self.inner.write(buf)?;
+        let total_written = self.total_written.get() + written;
+        self.total_written.set(total_written);
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}

--- a/dbcrossbarlib/src/rechunk.rs
+++ b/dbcrossbarlib/src/rechunk.rs
@@ -40,7 +40,8 @@ pub fn rechunk_csvs(
             .context("cannot read chunk header")?
             .to_owned();
 
-        /// A single output chunk. The state we need to generate a single `CsvStream`.
+        /// A single output chunk. The state we need to generate a single
+        /// `CsvStream`.
         struct Chunk<W: Write> {
             /// Write to this to add data to the chunk.
             wtr: csv::Writer<W>,
@@ -57,9 +58,8 @@ pub fn rechunk_csvs(
         // `CsvStream`s.
         let mut chunk_id: usize = 0;
 
-        // Construct a new `CsvStream`, and
-        // return a `Chunk` with a `csv::Writer` which can be used to write data to
-        // it.
+        // Construct a new `CsvStream`, and return a `Chunk` with a
+        // `csv::Writer` which can be used to write data to it.
         let mut new_chunk = || -> Result<Chunk<_>> {
             chunk_id = chunk_id.checked_add(1).expect("too many chunks");
             trace!(worker_ctx.log(), "starting new CSV chunk {}", chunk_id);


### PR DESCRIPTION
This allows controlling the approximate size of the individual CSV data
streams manipulated by `dbcrossbar`. We implement this by merging all
out input streams into a single `CsvStream`, then breaking it up again
into multiple `CsvStream` objects of approximately the requested size.

A couple of tricks were involved:

- The `CountingWriter` counts are not very accurate because of buffering
  in `csv::Writer`. We can adjust the buffering but it won't get us
  exact counts.
- We don't want to send a newly-created `CsvStream` to
  `csv_streams_sender` until we know that it will contain at least one
  line.

This involved some fairly fiddly async+sync Rust because of the nature
of combining and re-splitting multiple async streams using a sync `csv`
library. Many thanks to @n1ywb and @fwallacevt for pairing on this
patch!