### PR TITLE
Replace spaces in column names to satisfy BigQuery naming rules

### DIFF
--- a/dbcrossbarlib/src/drivers/bigquery_shared/column.rs
+++ b/dbcrossbarlib/src/drivers/bigquery_shared/column.rs
@@ -58,7 +58,7 @@ impl BqColumn {
             }
             BqDataType::NonArray(ty) => (ty, Mode::Required),
         };
-        let spaces_and_dashes_re = Regex::new(r"[-\s]").unwrap();
+        let spaces_and_dashes_re = Regex::new(r"[^a-zA-Z0-9_]").unwrap();
         let new_column_name = spaces_and_dashes_re.replace_all(&col.name, "_");
         Ok(BqColumn {
             name: new_column_name.to_string(),

--- a/dbcrossbarlib/src/drivers/bigquery_shared/column.rs
+++ b/dbcrossbarlib/src/drivers/bigquery_shared/column.rs
@@ -47,7 +47,7 @@ impl BqColumn {
     /// Given a portable `Column`, and an intended usage, return a corresponding
     /// `BqColumn`.
     ///
-    /// Note that dashes are replaced with underscores to satisfy BigQuery naming rules.
+    /// Note that dashes and spaces are replaced with underscores to satisfy BigQuery naming rules.
     pub(crate) fn for_column(col: &Column, usage: Usage) -> Result<BqColumn> {
         let bq_data_type = BqDataType::for_data_type(&col.data_type, usage)?;
         let (ty, mode): (BqNonArrayDataType, Mode) = match bq_data_type {
@@ -58,7 +58,11 @@ impl BqColumn {
             BqDataType::NonArray(ty) => (ty, Mode::Required),
         };
         Ok(BqColumn {
-            name: col.name.replace('-', &'_'.to_string()).to_owned(),
+            name: col
+                .name
+                .replace('-', &'_'.to_string())
+                .replace(' ', &'_'.to_string())
+                .to_owned(),
             description: None,
             ty,
             mode,

--- a/dbcrossbarlib/src/drivers/bigquery_shared/column.rs
+++ b/dbcrossbarlib/src/drivers/bigquery_shared/column.rs
@@ -1,5 +1,6 @@
 //! BigQuery columns.
 
+use regex::Regex;
 use serde_derive::{Deserialize, Serialize};
 use std::{fmt, io::Write};
 
@@ -57,12 +58,10 @@ impl BqColumn {
             }
             BqDataType::NonArray(ty) => (ty, Mode::Required),
         };
+        let spaces_and_dashes_re = Regex::new(r"[-\s]").unwrap();
+        let new_column_name = spaces_and_dashes_re.replace_all(&col.name, "_");
         Ok(BqColumn {
-            name: col
-                .name
-                .replace('-', &'_'.to_string())
-                .replace(' ', &'_'.to_string())
-                .to_owned(),
+            name: new_column_name.to_string(),
             description: None,
             ty,
             mode,


### PR DESCRIPTION
This PR replaces spaces in column names with underscores to satisfy BigQuery naming rules