### PR TITLE
Support strange column names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "bigml"
-version = "0.4.0-alpha.3"
+version = "0.4.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bigml_derive 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -468,7 +468,7 @@ name = "dbcrossbarlib"
 version = "0.2.1"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bigml 0.4.0-alpha.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bigml 0.4.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2607,7 +2607,7 @@ dependencies = [
 "checksum backtrace 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)" = "5180c5a20655b14a819b652fd2378fa5f1697b6c9ddad3e695c2f9cedf6df4e2"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-"checksum bigml 0.4.0-alpha.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c2089e9201c31736698f3ebb712c15c9cb2fd3a025d670476797fbb94ff9e825"
+"checksum bigml 0.4.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f52d33b74b11dfca287469c31a7f93a8f9543ee1539faecbe95a017b4ed32dc0"
 "checksum bigml_derive 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5629b0b1e2d44a155d7b315820e94d99e8de998ed392f7e405dd239182a65155"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum blake2b_simd 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "5850aeee1552f495dd0250014cf64b82b7c8879a89d83b33bbdace2cc4f63182"

--- a/dbcrossbar/fixtures/tricky_column_names.csv
+++ b/dbcrossbar/fixtures/tricky_column_names.csv
@@ -1,0 +1,2 @@
+"person__Delivery Zone 4.14","person__$Region - 8/1","person__Do you have any allergies?",name,Name
+a,b,c,d,e

--- a/dbcrossbar/fixtures/tricky_column_names.sql
+++ b/dbcrossbar/fixtures/tricky_column_names.sql
@@ -1,0 +1,7 @@
+CREATE TABLE tricky_column_names (
+  "person__Delivery Zone 4.14" text,
+  "person__$Region - 8/1" text,
+  "person__Do you have any allergies?" text,
+  "name" text,
+  "Name" text
+)

--- a/dbcrossbar/fixtures/tricky_column_names_expected.csv
+++ b/dbcrossbar/fixtures/tricky_column_names_expected.csv
@@ -1,0 +1,2 @@
+person__delivery_zone_4_14,person___region___8_1,person__do_you_have_any_allergies_,name,name_2
+a,b,c,d,e

--- a/dbcrossbar/tests/tests.rs
+++ b/dbcrossbar/tests/tests.rs
@@ -351,6 +351,81 @@ fn cp_csv_to_postgres_to_gs_to_csv() {
 
 #[test]
 #[ignore]
+fn cp_tricky_column_names() {
+    let _ = env_logger::try_init();
+    let testdir = TestDir::new("dbcrossbar", "cp_tricky_column_names");
+    let src = testdir.src_path("fixtures/tricky_column_names.csv");
+    let expected = testdir.src_path("fixtures/tricky_column_names_expected.csv");
+    let schema = testdir.src_path("fixtures/tricky_column_names.sql");
+    let pg_table = post_test_table_url("testme1.cp_tricky_column_names");
+    let bq_table = bq_test_table("cp_tricky_column_names");
+    let gs_temp_dir = gs_test_dir_url("cp_from_bigquery_with_where");
+    let bq_temp_ds = bq_temp_dataset();
+
+    // CSV to Postgres.
+    testdir
+        .cmd()
+        .args(&[
+            "cp",
+            "--if-exists=overwrite",
+            &format!("--schema=postgres-sql:{}", schema.display()),
+            &format!("csv:{}", src.display()),
+            &pg_table,
+        ])
+        .tee_output()
+        .expect_success();
+
+    // Postgres to BigQuery.
+    testdir
+        .cmd()
+        .args(&[
+            "cp",
+            "--if-exists=overwrite",
+            &format!("--schema=postgres-sql:{}", schema.display()),
+            &format!("--temporary={}", gs_temp_dir),
+            &format!("--temporary={}", bq_temp_ds),
+            &pg_table,
+            &bq_table,
+        ])
+        .tee_output()
+        .expect_success();
+
+    // Postgres to BigQuery.
+    testdir
+        .cmd()
+        .args(&[
+            "cp",
+            "--if-exists=upsert-on:person__Delivery Zone 4.14",
+            &format!("--schema=postgres-sql:{}", schema.display()),
+            &format!("--temporary={}", gs_temp_dir),
+            &format!("--temporary={}", bq_temp_ds),
+            &pg_table,
+            &bq_table,
+        ])
+        .tee_output()
+        .expect_success();
+
+    // BigQuery back to CSV for the final comparison below.
+    testdir
+        .cmd()
+        .args(&[
+            "cp",
+            &format!("--schema=postgres-sql:{}", schema.display()),
+            &format!("--temporary={}", gs_temp_dir),
+            &format!("--temporary={}", bq_temp_ds),
+            &bq_table,
+            "csv:out.csv",
+        ])
+        .tee_output()
+        .expect_success();
+
+    let expected = fs::read_to_string(&expected).unwrap();
+    let actual = fs::read_to_string(testdir.path("out.csv")).unwrap();
+    assert_diff!(&expected, &actual, ",", 0);
+}
+
+#[test]
+#[ignore]
 fn cp_csv_to_postgres_append() {
     let testdir = TestDir::new("dbcrossbar", "cp_csv_to_postgres_append");
     let src = testdir.src_path("fixtures/many_types.csv");

--- a/dbcrossbarlib/Cargo.toml
+++ b/dbcrossbarlib/Cargo.toml
@@ -21,7 +21,7 @@ slog-term = "2.4.0"
 
 [dependencies]
 base64 = "0.10.1"
-bigml = "0.4.0-alpha.3"
+bigml = "0.4.0-alpha.4"
 bitflags = "1.1.0"
 byteorder = "1.3.1"
 bytes = "0.4.11"

--- a/dbcrossbarlib/src/drivers/bigquery_shared/column.rs
+++ b/dbcrossbarlib/src/drivers/bigquery_shared/column.rs
@@ -6,6 +6,7 @@ use std::{fmt, io::Write};
 use super::{BqDataType, BqNonArrayDataType, DataTypeBigQueryExt, Usage};
 use crate::common::*;
 use crate::schema::Column;
+use crate::uniquifier::Uniquifier;
 
 /// Extensions to `Column` (the portable version) to handle BigQuery-query
 /// specific stuff.
@@ -31,6 +32,11 @@ pub(crate) struct BqColumn {
     /// The name of the BigQuery column.
     pub name: String,
 
+    /// The original name of this field in our portable schema, if any. Used
+    /// internally.
+    #[serde(skip)]
+    pub(crate) external_name: Option<String>,
+
     /// The type of the BigQuery column.
     #[serde(rename = "type")]
     ty: BqNonArrayDataType,
@@ -47,8 +53,12 @@ impl BqColumn {
     /// Given a portable `Column`, and an intended usage, return a corresponding
     /// `BqColumn`.
     ///
-    /// Note that dashes are replaced with underscores to satisfy BigQuery naming rules.
-    pub(crate) fn for_column(col: &Column, usage: Usage) -> Result<BqColumn> {
+    /// Note that dashes and spaces are replaced with underscores to satisfy BigQuery naming rules.
+    pub(crate) fn for_column(
+        col: &Column,
+        usage: Usage,
+        uniquifier: &mut Uniquifier,
+    ) -> Result<BqColumn> {
         let bq_data_type = BqDataType::for_data_type(&col.data_type, usage)?;
         let (ty, mode): (BqNonArrayDataType, Mode) = match bq_data_type {
             BqDataType::Array(ty) => (ty, Mode::Repeated),
@@ -58,7 +68,8 @@ impl BqColumn {
             BqDataType::NonArray(ty) => (ty, Mode::Required),
         };
         Ok(BqColumn {
-            name: col.name.replace('-', &'_'.to_string()).to_owned(),
+            name: uniquifier.unique_id_for(&col.name)?.to_owned(),
+            external_name: Some(col.name.clone()),
             description: None,
             ty,
             mode,

--- a/dbcrossbarlib/src/drivers/postgres_shared/mod.rs
+++ b/dbcrossbarlib/src/drivers/postgres_shared/mod.rs
@@ -40,15 +40,6 @@ pub(crate) struct Ident<'a>(pub(crate) &'a str);
 
 impl<'a> fmt::Display for Ident<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if self.0.contains('.') {
-            // Unfortunately, we have no good way to report a more detailed
-            // error from here. But we do not way to see "." in names until
-            // we're sure that `TableName` is used everywhere it should be.
-            //
-            // We could take this out later, if we're sure we trust people to
-            // always use `TableName` when required.
-            return Err(fmt::Error);
-        }
         write!(f, "\"")?;
         write!(f, "{}", self.0.replace('"', "\"\""))?;
         write!(f, "\"")?;

--- a/dbcrossbarlib/src/lib.rs
+++ b/dbcrossbarlib/src/lib.rs
@@ -31,6 +31,7 @@ pub(crate) mod separator;
 mod temporary_storage;
 pub mod tokio_glue;
 pub(crate) mod transform;
+pub(crate) mod uniquifier;
 
 /// Standard error type for this library.
 pub use failure::Error;

--- a/dbcrossbarlib/src/uniquifier.rs
+++ b/dbcrossbarlib/src/uniquifier.rs
@@ -1,0 +1,80 @@
+//! Make unique identifiers from messy strings.
+
+use std::collections::HashSet;
+
+use crate::common::*;
+
+/// Turns arbitrary Unicode names into unique, lowercase ASCII identifiers. All
+/// identifiers start with an underscore or a lowercase ASCII letter, followed
+/// by zero or more underscores, lowercase ASCII letters and digits.
+#[derive(Debug, Default)]
+pub(crate) struct Uniquifier {
+    /// Identifiers that we have already generated.
+    used: HashSet<String>,
+}
+
+impl Uniquifier {
+    /// Given a `name`, return an idenfitier
+    pub(crate) fn unique_id_for<'a>(&mut self, name: &'a str) -> Result<&str> {
+        let id = name_to_lowercase_id(name);
+        if self.used.insert(id.to_owned()) {
+            Ok(&self.used.get(&id).expect("just verified id was present")[..])
+        } else {
+            let mut offset = 1;
+            while offset < 50 {
+                offset += 1;
+                let alt_id = format!("{}_{}", id, offset);
+                if self.used.insert(alt_id.to_owned()) {
+                    return Ok(&self
+                        .used
+                        .get(&alt_id)
+                        .expect("just verified alt_id was present")[..]);
+                }
+            }
+            Err(format_err!("too many name collisions"))
+        }
+    }
+}
+
+#[test]
+fn uniquifier_generates_unique_ids() {
+    let examples = &[
+        ("a", "a"),
+        ("A", "a_2"),
+        ("a_2", "a_2_2"), // Sneaky.
+        ("B", "b"),
+    ];
+    let mut uniqifier = Uniquifier::default();
+    for &(input, expected) in examples {
+        assert_eq!(uniqifier.unique_id_for(input).unwrap(), expected);
+    }
+}
+
+/// Given a unique string, turn it into a lower-case identifier.
+fn name_to_lowercase_id(name: &str) -> String {
+    if name.is_empty() {
+        "_".to_owned()
+    } else {
+        name.char_indices()
+            .map(|(idx, c)| {
+                if c == '_' || c.is_ascii_lowercase() {
+                    c
+                } else if c.is_ascii_uppercase() {
+                    c.to_ascii_lowercase()
+                } else if idx != 0 && c.is_ascii_digit() {
+                    c
+                } else {
+                    '_'
+                }
+            })
+            .collect::<String>()
+    }
+}
+
+#[test]
+fn name_to_lowercase_id_cleans_non_id_characters() {
+    let examples = &[("", "_"), ("_aA1?", "_aa1_"), ("1", "_")];
+    for &(input, expected) in examples {
+        assert_eq!(name_to_lowercase_id(input), expected);
+    }
+}


### PR DESCRIPTION
We now support column names like:

- `column 1.2`
- `First Name`
- `First name`

...all in the same database.

For BigQuery, this requires us to transform portable column names into
legal BigQuery column names, and append numbers to them to prevent name
clashes.

For PostgreSQL, this requires allowing column names with periods, like
"column 1.2", in the PostgreSQL driver.

Written with @seamusabshere.