### PR TITLE
Properly handle null upsert keys

### DIFF
--- a/dbcrossbarlib/src/drivers/bigquery_shared/table.rs
+++ b/dbcrossbarlib/src/drivers/bigquery_shared/table.rs
@@ -7,7 +7,7 @@ use std::{
     io::Write,
 };
 
-use super::{BqColumn, ColumnBigQueryExt, Ident, Mode, TableName, Usage};
+use super::{BqColumn, ColumnBigQueryExt, Ident, TableName, Usage};
 use crate::common::*;
 use crate::schema::{Column, Table};
 use crate::uniquifier::Uniquifier;

--- a/dbcrossbarlib/src/drivers/bigquery_shared/table.rs
+++ b/dbcrossbarlib/src/drivers/bigquery_shared/table.rs
@@ -162,7 +162,7 @@ MERGE INTO {dest_table} AS dest
 USING (
   SELECT
     *
-  FROM {temp_table}
+  FROM {temp_table} AS temp
   WHERE
     {key_not_null_constaints}
 ) AS temp

--- a/dbcrossbarlib/src/drivers/bigquery_shared/table.rs
+++ b/dbcrossbarlib/src/drivers/bigquery_shared/table.rs
@@ -135,18 +135,6 @@ impl BqTable {
             })
             .collect::<Result<Vec<&BqColumn>>>()?;
 
-        // As discussed at https://github.com/faradayio/dbcrossbar/issues/43,
-        // it's not obvious how to `MERGE` on columns that might be `NULL`.
-        // Until we have a solution that we like, fail with an error.
-        for merge_key in &merge_keys {
-            if merge_key.mode != Mode::Required {
-                return Err(format_err!(
-                    "BigQuery cannot upsert on {:?} because it is not REQUIRED (aka NOT NULL)",
-                    merge_key.name,
-                ));
-            }
-        }
-
         // Build a table when we can check for merge keys by name.
         let merge_key_table = merge_keys
             .iter()


### PR DESCRIPTION
When you naively upsert against a column that might be null, you risk creating duplicate rows (and not updating the data you expect) because null does not equal null.

In the past, we raised an error if a table didn't enforce NOT NULL (or REQUIRED on BigQuery). This prevented people from making mistakes, but it made it very hard to use dbcrossbar against legacy tables (or with data that may contain a negligible fraction of nulls that you want to ignore).

This PR removes the NOT NULL enforcement. It also adds a subquery into the upsert MERGE statement that drops rows that have null upsert keys. This will be the desired behavior 95% of the time.