### PR TITLE
Add a `dbcrossbar count` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,6 +413,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling_core 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "darling_macro 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,6 +434,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +454,16 @@ dependencies = [
  "darling_core 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling_core 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -469,13 +501,13 @@ version = "0.2.2"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bigml 0.4.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "enumset 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "geo-types 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -585,6 +617,26 @@ version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "enumset"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "enumset_derive 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "enumset_derive"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1947,6 +1999,11 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "strsim"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "structopt"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2619,8 +2676,11 @@ dependencies = [
 "checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 "checksum csv 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "37519ccdfd73a75821cac9319d4fce15a81b9fcf75f951df5b9988aa3a0af87d"
 "checksum csv-core 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9b5cadb6b25c77aeff80ba701712494213f4a8418fcda2ee11b6560c3ad0bf4c"
+"checksum darling 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe629a532efad5526454efb0700f86d5ad7ff001acb37e431c8bf017a432a8e"
 "checksum darling 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9158d690bc62a3a57c3e45b85e4d50de2008b39345592c64efd79345c7e24be0"
+"checksum darling_core 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ee54512bec54b41cf2337a22ddfadb53c7d4c738494dc2a186d7b037ad683b85"
 "checksum darling_core 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d2a368589465391e127e10c9e3a08efc8df66fd49b87dc8524c764bbe7f2ef82"
+"checksum darling_macro 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0cd3e432e52c0810b72898296a69d66b1d78d1517dff6cde7a130557a55a62c1"
 "checksum darling_macro 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)" = "244e8987bd4e174385240cde20a3657f607fb0797563c28255c353b5819a07b1"
 "checksum derive_state_machine_future 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1220ad071cb8996454c20adf547a34ba3ac793759dab793d9dc04996a373ac83"
 "checksum diesel 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8d24935ba50c4a8dc375a0fd1f8a2ba6bdbdc4125713126a74b965d6a01a06d7"
@@ -2631,6 +2691,8 @@ dependencies = [
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum encoding_rs 0.8.20 (registry+https://github.com/rust-lang/crates.io-index)" = "87240518927716f79692c2ed85bfe6e98196d18c6401ec75355760233a7e12e9"
+"checksum enumset 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "57b811aef4ff1cc938f13bbec348f0ecbfc2bb565b7ab90161c9f0b2805edc8a"
+"checksum enumset_derive 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b184c2d0714bbeeb6440481a19c78530aa210654d99529f13d2f860a1b447598"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
@@ -2786,6 +2848,7 @@ dependencies = [
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
 "checksum stringprep 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8ee348cb74b87454fff4b551cbf727025810a004f88aeacae7f85b87f4e9a1c1"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+"checksum strsim 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "032c03039aae92b350aad2e3779c352e104d919cb192ba2fabbd7b831ce4f0f6"
 "checksum structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4f66a4c0ddf7aee4677995697366de0749b0139057342eccbb609b12d0affc"
 "checksum structopt-derive 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8fe0c13e476b4e21ff7f5c4ace3818b6d7bdc16897c31c73862471bc1663acae"
 "checksum strum 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6138f8f88a16d90134763314e3fc76fa3ed6a7db4725d6acf9a3ef95a3188d22"

--- a/dbcrossbar/src/cmd/conv.rs
+++ b/dbcrossbar/src/cmd/conv.rs
@@ -1,4 +1,4 @@
-//! The `schema` subcommand.
+//! The `conv` subcommand.
 
 use common_failures::Result;
 use dbcrossbarlib::{BoxLocator, Context, IfExists};

--- a/dbcrossbar/src/cmd/count.rs
+++ b/dbcrossbar/src/cmd/count.rs
@@ -1,0 +1,63 @@
+//! The `count` subcommand.
+
+use common_failures::Result;
+use dbcrossbarlib::{
+    BoxLocator, Context, DriverArguments, SharedArguments, SourceArguments,
+    TemporaryStorage,
+};
+use failure::{format_err, ResultExt};
+use structopt::{self, StructOpt};
+
+/// Count arguments.
+#[derive(Debug, StructOpt)]
+pub(crate) struct Opt {
+    /// The schema to use (defaults to input table schema).
+    #[structopt(long = "schema")]
+    schema: Option<BoxLocator>,
+
+    /// Temporary directories, cloud storage buckets, datasets to use during
+    /// transfer (can be repeated).
+    #[structopt(long = "temporary")]
+    temporaries: Vec<String>,
+
+    /// Pass an extra argument of the form `key=value` to the source driver.
+    #[structopt(long = "from-arg")]
+    from_args: Vec<String>,
+
+    /// SQL where clause specifying rows to use.
+    #[structopt(long = "where")]
+    where_clause: Option<String>,
+
+    /// The locator specifying the records to count.
+    locator: BoxLocator,
+}
+
+/// Count records.
+pub(crate) async fn run(ctx: Context, opt: Opt) -> Result<()> {
+    // Figure out what table schema to use.
+    let schema = {
+        let schema_locator = opt.schema.as_ref().unwrap_or(&opt.locator);
+        schema_locator
+            .schema(ctx.clone())
+            .await
+            .with_context(|_| format!("error reading schema from {}", opt.locator))?
+            .ok_or_else(|| {
+                format_err!("don't know how to read schema from {}", opt.locator)
+            })
+    }?;
+
+    // Build our shared arguments.
+    let temporary_storage = TemporaryStorage::new(opt.temporaries.clone());
+    let shared_args = SharedArguments::new(schema, temporary_storage);
+
+    // Build our source arguments.
+    let from_args = DriverArguments::from_cli_args(&opt.from_args)?;
+    let source_args = SourceArguments::new(from_args, opt.where_clause.clone());
+
+    let count = opt
+        .locator
+        .count(ctx.clone(), shared_args, source_args)
+        .await?;
+    println!("{}", count);
+    Ok(())
+}

--- a/dbcrossbar/src/cmd/mod.rs
+++ b/dbcrossbar/src/cmd/mod.rs
@@ -8,6 +8,7 @@ use structopt_derive::StructOpt;
 use crate::logging::LogFormat;
 
 pub(crate) mod conv;
+pub(crate) mod count;
 pub(crate) mod cp;
 pub(crate) mod features;
 
@@ -46,6 +47,17 @@ pub(crate) enum Command {
         command: conv::Opt,
     },
 
+    /// Count records.
+    #[structopt(name = "count")]
+    #[structopt(after_help = r#"EXAMPLE LOCATORS:
+    postgres://localhost:5432/db#table
+    bigquery:project:dataset.table
+"#)]
+    Count {
+        #[structopt(flatten)]
+        command: count::Opt,
+    },
+
     /// Copy tables from one location to another.
     #[structopt(name = "cp")]
     #[structopt(after_help = r#"EXAMPLE LOCATORS:
@@ -68,6 +80,7 @@ pub(crate) enum Command {
 pub(crate) fn run(ctx: Context, opt: Opt) -> BoxFuture<()> {
     match opt.cmd {
         Command::Conv { command } => conv::run(ctx, command).boxed(),
+        Command::Count { command } => count::run(ctx, command).boxed(),
         Command::Cp { command } => cp::run(ctx, command).boxed(),
         Command::Features { command } => features::run(ctx, command).boxed(),
     }

--- a/dbcrossbar/tests/tests.rs
+++ b/dbcrossbar/tests/tests.rs
@@ -931,3 +931,69 @@ fn cp_csv_to_bigml_dataset_to_csv() {
     assert!(output.stdout_str().contains("CREATE TABLE"));
     assert!(output.stdout_str().contains("test_null"));
 }
+
+#[test]
+#[ignore]
+fn count_bigquery() {
+    let testdir = TestDir::new("dbcrossbar", "count_bigquery");
+    let src = testdir.src_path("fixtures/posts.csv");
+    let schema = testdir.src_path("fixtures/posts.sql");
+    let gs_temp_dir = gs_test_dir_url("count_bigquery");
+    let bq_temp_ds = bq_temp_dataset();
+    let bq_table = bq_test_table("count_bigquery");
+
+    // CSV to BigQuery.
+    testdir
+        .cmd()
+        .args(&[
+            "cp",
+            "--if-exists=overwrite",
+            &format!("--temporary={}", gs_temp_dir),
+            &format!("--temporary={}", bq_temp_ds),
+            &format!("--schema=postgres-sql:{}", schema.display()),
+            &format!("csv:{}", src.display()),
+            &bq_table,
+        ])
+        .tee_output()
+        .expect_success();
+
+    // Count BigQuery.
+    let output = testdir
+        .cmd()
+        .args(&["count", &bq_table])
+        .tee_output()
+        .expect_success();
+
+    assert_eq!(output.stdout_str().trim(), "2");
+}
+
+#[test]
+#[ignore]
+fn count_postgres() {
+    let testdir = TestDir::new("dbcrossbar", "count_postgres");
+    let src = testdir.src_path("fixtures/posts.csv");
+    let schema = testdir.src_path("fixtures/posts.sql");
+    let pg_table = post_test_table_url("count_postgres");
+
+    // CSV to PostgreSQL.
+    testdir
+        .cmd()
+        .args(&[
+            "cp",
+            "--if-exists=overwrite",
+            &format!("--schema=postgres-sql:{}", schema.display()),
+            &format!("csv:{}", src.display()),
+            &pg_table,
+        ])
+        .tee_output()
+        .expect_success();
+
+    // Count PostgreSQL.
+    let output = testdir
+        .cmd()
+        .args(&["count", &pg_table])
+        .tee_output()
+        .expect_success();
+
+    assert_eq!(output.stdout_str().trim(), "2");
+}

--- a/dbcrossbarlib/Cargo.toml
+++ b/dbcrossbarlib/Cargo.toml
@@ -22,13 +22,13 @@ slog-term = "2.4.0"
 [dependencies]
 base64 = "0.10.1"
 bigml = "0.4.0-alpha.4"
-bitflags = "1.1.0"
 byteorder = "1.3.1"
 bytes = "0.4.11"
 cast = "0.2.2"
 chrono = "0.4.6"
 csv = "1.0.5"
 diesel = { version = "1.3.3", features = ["postgres"] }
+enumset = "0.4.4"
 failure = "0.1.2"
 futures-preview = { version = "0.3.0-alpha.17", features = ["compat"] }
 geo-types = "0.4"

--- a/dbcrossbarlib/src/drivers/bigml/mod.rs
+++ b/dbcrossbarlib/src/drivers/bigml/mod.rs
@@ -234,15 +234,15 @@ impl LocatorStatic for BigMlLocator {
 
     fn features() -> Features {
         Features {
-            locator: LocatorFeatures::SCHEMA
-                | LocatorFeatures::LOCAL_DATA
-                | LocatorFeatures::WRITE_LOCAL_DATA,
-            write_schema_if_exists: IfExistsFeatures::empty(),
-            source_args: SourceArgumentsFeatures::empty(),
-            dest_args: DestinationArgumentsFeatures::DRIVER_ARGS,
+            locator: LocatorFeatures::Schema
+                | LocatorFeatures::LocalData
+                | LocatorFeatures::WriteLocalData,
+            write_schema_if_exists: EnumSet::empty(),
+            source_args: EnumSet::empty(),
+            dest_args: DestinationArgumentsFeatures::DriverArgs.into(),
             // We allow all `--if-exists` features because we always generate a
             // unique destination name.
-            dest_if_exists: IfExistsFeatures::all(),
+            dest_if_exists: EnumSet::all(),
             _placeholder: (),
         }
     }

--- a/dbcrossbarlib/src/drivers/bigquery/count.rs
+++ b/dbcrossbarlib/src/drivers/bigquery/count.rs
@@ -1,0 +1,98 @@
+//! Implementation of `count`, but as a real `async` function.
+
+use serde::Deserialize;
+use std::process::{Command, Stdio};
+use tokio::io;
+use tokio_process::CommandExt;
+
+use crate::common::*;
+use crate::drivers::{
+    bigquery::BigQueryLocator,
+    bigquery_shared::{BqTable, Usage},
+};
+
+/// Implementation of `count`, but as a real `async` function.
+pub(crate) async fn count_helper(
+    ctx: Context,
+    locator: BigQueryLocator,
+    shared_args: SharedArguments<Unverified>,
+    source_args: SourceArguments<Unverified>,
+) -> Result<usize> {
+    let shared_args = shared_args.verify(BigQueryLocator::features())?;
+    let source_args = source_args.verify(BigQueryLocator::features())?;
+
+    // Look up the arguments we need.
+    let schema = shared_args.schema();
+
+    // Construct a `BqTable` describing our source table.
+    let table_name = locator.as_table_name().to_owned();
+    let table = BqTable::for_table_name_and_columns(
+        table_name,
+        &schema.columns,
+        Usage::FinalTable,
+    )?;
+
+    // Generate our count SQL.
+    let mut count_sql_data = vec![];
+    table.write_count_sql(&source_args, &mut count_sql_data)?;
+    let count_sql = String::from_utf8(count_sql_data).expect("should always be UTF-8");
+    debug!(ctx.log(), "count SQL: {}", count_sql);
+
+    // Run our query.
+    debug!(ctx.log(), "running `bq query`");
+    let mut query_child = Command::new("bq")
+        // We'll pass the query on `stdin`.
+        .stdin(Stdio::piped())
+        // We'll read output from `stdout`.
+        .stdout(Stdio::piped())
+        // Run query with no output.
+        .args(&["query", "--headless", "--format=json", "--nouse_legacy_sql"])
+        .spawn_async()
+        .context("error starting `bq query`")?;
+    let child_stdin = query_child
+        .stdin()
+        .take()
+        .expect("don't have stdin that we requested");
+    io::write_all(child_stdin, count_sql)
+        .compat()
+        .await
+        .context("error piping query to `bq query`")?;
+    let child_stdout = query_child
+        .stdout()
+        .take()
+        .expect("don't have stdout that we requested");
+    let output = vec![];
+    let (_child_stdout, output) = io::read_to_end(child_stdout, output)
+        .compat()
+        .await
+        .context("error reading output from `bq query`")?;
+    let output = String::from_utf8(output)?;
+    debug!(ctx.log(), "bq count output: {}", output.trim());
+
+    let status = query_child
+        .compat()
+        .await
+        .context("error running `bq query`")?;
+    if !status.success() {
+        return Err(format_err!("`bq query` failed with {}", status));
+    }
+
+    // Parse our output, and get the count.
+    #[derive(Deserialize)]
+    struct CountRow {
+        count: String,
+    }
+    let rows = serde_json::from_str::<Vec<CountRow>>(&output)
+        .context("could not parse count output")?;
+    if rows.len() != 1 {
+        Err(format_err!(
+            "expected 1 row of count output, got {}",
+            rows.len(),
+        ))
+    } else {
+        Ok(rows[0]
+            .count
+            .parse::<usize>()
+            .context("could not parse count output")?)
+    }
+}

--- a/dbcrossbarlib/src/drivers/bigquery/mod.rs
+++ b/dbcrossbarlib/src/drivers/bigquery/mod.rs
@@ -109,15 +109,15 @@ impl LocatorStatic for BigQueryLocator {
 
     fn features() -> Features {
         Features {
-            locator: LocatorFeatures::SCHEMA
-                | LocatorFeatures::LOCAL_DATA
-                | LocatorFeatures::WRITE_LOCAL_DATA,
-            write_schema_if_exists: IfExistsFeatures::empty(),
-            source_args: SourceArgumentsFeatures::WHERE_CLAUSE,
-            dest_args: DestinationArgumentsFeatures::empty(),
-            dest_if_exists: IfExistsFeatures::OVERWRITE
-                | IfExistsFeatures::APPEND
-                | IfExistsFeatures::UPSERT,
+            locator: LocatorFeatures::Schema
+                | LocatorFeatures::LocalData
+                | LocatorFeatures::WriteLocalData,
+            write_schema_if_exists: EnumSet::empty(),
+            source_args: SourceArgumentsFeatures::WhereClause.into(),
+            dest_args: EnumSet::empty(),
+            dest_if_exists: IfExistsFeatures::Overwrite
+                | IfExistsFeatures::Append
+                | IfExistsFeatures::Upsert,
             _placeholder: (),
         }
     }

--- a/dbcrossbarlib/src/drivers/bigquery/mod.rs
+++ b/dbcrossbarlib/src/drivers/bigquery/mod.rs
@@ -5,11 +5,13 @@ use std::{fmt, str::FromStr};
 use crate::common::*;
 use crate::drivers::{bigquery_shared::TableName, gs::GsLocator};
 
+mod count;
 mod local_data;
 mod schema;
 mod write_local_data;
 mod write_remote_data;
 
+use self::count::count_helper;
 use self::local_data::local_data_helper;
 use self::schema::schema_helper;
 use self::write_local_data::write_local_data_helper;
@@ -54,6 +56,15 @@ impl Locator for BigQueryLocator {
 
     fn schema(&self, ctx: Context) -> BoxFuture<Option<Table>> {
         schema_helper(ctx, self.to_owned()).boxed()
+    }
+
+    fn count(
+        &self,
+        ctx: Context,
+        shared_args: SharedArguments<Unverified>,
+        source_args: SourceArguments<Unverified>,
+    ) -> BoxFuture<usize> {
+        count_helper(ctx, self.to_owned(), shared_args, source_args).boxed()
     }
 
     fn local_data(
@@ -111,7 +122,8 @@ impl LocatorStatic for BigQueryLocator {
         Features {
             locator: LocatorFeatures::Schema
                 | LocatorFeatures::LocalData
-                | LocatorFeatures::WriteLocalData,
+                | LocatorFeatures::WriteLocalData
+                | LocatorFeatures::Count,
             write_schema_if_exists: EnumSet::empty(),
             source_args: SourceArgumentsFeatures::WhereClause.into(),
             dest_args: EnumSet::empty(),

--- a/dbcrossbarlib/src/drivers/bigquery/write_remote_data.rs
+++ b/dbcrossbarlib/src/drivers/bigquery/write_remote_data.rs
@@ -163,7 +163,7 @@ pub(crate) async fn write_remote_data_helper(
                 // Pass separately, because paths may not be UTF-8.
                 .arg(&dest_schema_path)
                 .arg(&dest_table.name().to_string())
-        // Throw away stdout so it doesn't corrupt our output.
+                // Throw away stdout so it doesn't corrupt our output.
                 .stdout(Stdio::null())
                 .spawn_async()
                 .context("error starting `bq mk`")?;

--- a/dbcrossbarlib/src/drivers/bigquery_schema/mod.rs
+++ b/dbcrossbarlib/src/drivers/bigquery_schema/mod.rs
@@ -52,11 +52,11 @@ impl LocatorStatic for BigQuerySchemaLocator {
 
     fn features() -> Features {
         Features {
-            locator: LocatorFeatures::SCHEMA | LocatorFeatures::WRITE_SCHEMA,
+            locator: LocatorFeatures::Schema | LocatorFeatures::WriteSchema,
             write_schema_if_exists: IfExistsFeatures::no_append(),
-            source_args: SourceArgumentsFeatures::empty(),
-            dest_args: DestinationArgumentsFeatures::empty(),
-            dest_if_exists: IfExistsFeatures::empty(),
+            source_args: EnumSet::empty(),
+            dest_args: EnumSet::empty(),
+            dest_if_exists: EnumSet::empty(),
             _placeholder: (),
         }
     }

--- a/dbcrossbarlib/src/drivers/bigquery_shared/table.rs
+++ b/dbcrossbarlib/src/drivers/bigquery_shared/table.rs
@@ -237,4 +237,18 @@ WHEN NOT MATCHED THEN INSERT (
         }
         Ok(())
     }
+
+    pub(crate) fn write_count_sql(
+        &self,
+        source_args: &SourceArguments<Verified>,
+        f: &mut dyn Write,
+    ) -> Result<()> {
+        write!(f, "SELECT COUNT(*) AS `count`")?;
+        write!(f, " FROM {}", Ident(&self.name.dotted().to_string()))?;
+        if let Some(where_clause) = source_args.where_clause() {
+            write!(f, " WHERE ({})", where_clause)?;
+        }
+
+        Ok(())
+    }
 }

--- a/dbcrossbarlib/src/drivers/csv/mod.rs
+++ b/dbcrossbarlib/src/drivers/csv/mod.rs
@@ -322,12 +322,12 @@ impl LocatorStatic for CsvLocator {
 
     fn features() -> Features {
         Features {
-            locator: LocatorFeatures::SCHEMA
-                | LocatorFeatures::LOCAL_DATA
-                | LocatorFeatures::WRITE_LOCAL_DATA,
-            write_schema_if_exists: IfExistsFeatures::empty(),
-            source_args: SourceArgumentsFeatures::empty(),
-            dest_args: DestinationArgumentsFeatures::empty(),
+            locator: LocatorFeatures::Schema
+                | LocatorFeatures::LocalData
+                | LocatorFeatures::WriteLocalData,
+            write_schema_if_exists: EnumSet::empty(),
+            source_args: EnumSet::empty(),
+            dest_args: EnumSet::empty(),
             dest_if_exists: IfExistsFeatures::no_append(),
             _placeholder: (),
         }

--- a/dbcrossbarlib/src/drivers/dbcrossbar_schema/mod.rs
+++ b/dbcrossbarlib/src/drivers/dbcrossbar_schema/mod.rs
@@ -51,11 +51,11 @@ impl LocatorStatic for DbcrossbarSchemaLocator {
 
     fn features() -> Features {
         Features {
-            locator: LocatorFeatures::SCHEMA | LocatorFeatures::WRITE_SCHEMA,
+            locator: LocatorFeatures::Schema | LocatorFeatures::WriteSchema,
             write_schema_if_exists: IfExistsFeatures::no_append(),
-            source_args: SourceArgumentsFeatures::empty(),
-            dest_args: DestinationArgumentsFeatures::empty(),
-            dest_if_exists: IfExistsFeatures::empty(),
+            source_args: EnumSet::empty(),
+            dest_args: EnumSet::empty(),
+            dest_if_exists: EnumSet::empty(),
             _placeholder: (),
         }
     }

--- a/dbcrossbarlib/src/drivers/gs/mod.rs
+++ b/dbcrossbarlib/src/drivers/gs/mod.rs
@@ -112,11 +112,11 @@ impl LocatorStatic for GsLocator {
 
     fn features() -> Features {
         Features {
-            locator: LocatorFeatures::LOCAL_DATA | LocatorFeatures::WRITE_LOCAL_DATA,
-            write_schema_if_exists: IfExistsFeatures::empty(),
-            source_args: SourceArgumentsFeatures::empty(),
-            dest_args: DestinationArgumentsFeatures::empty(),
-            dest_if_exists: IfExistsFeatures::OVERWRITE,
+            locator: LocatorFeatures::LocalData | LocatorFeatures::WriteLocalData,
+            write_schema_if_exists: EnumSet::empty(),
+            source_args: EnumSet::empty(),
+            dest_args: EnumSet::empty(),
+            dest_if_exists: IfExistsFeatures::Overwrite.into(),
             _placeholder: (),
         }
     }

--- a/dbcrossbarlib/src/drivers/gs/write_remote_data.rs
+++ b/dbcrossbarlib/src/drivers/gs/write_remote_data.rs
@@ -82,7 +82,7 @@ pub(crate) async fn write_remote_data_helper(
     let child_stdin = query_child
         .stdin()
         .take()
-        .expect("don't have stdio that we requested");
+        .expect("don't have stdin that we requested");
     io::write_all(child_stdin, export_sql)
         .compat()
         .await

--- a/dbcrossbarlib/src/drivers/postgres/count.rs
+++ b/dbcrossbarlib/src/drivers/postgres/count.rs
@@ -1,0 +1,52 @@
+//! Implementation of `count`, but as a real `async` function.
+
+use super::{connect, PostgresLocator};
+use crate::common::*;
+use crate::drivers::postgres_shared::PgCreateTable;
+
+/// Implementation of `count`, but as a real `async` function.
+pub(crate) async fn count_helper(
+    ctx: Context,
+    locator: PostgresLocator,
+    shared_args: SharedArguments<Unverified>,
+    source_args: SourceArguments<Unverified>,
+) -> Result<usize> {
+    let shared_args = shared_args.verify(PostgresLocator::features())?;
+    let source_args = source_args.verify(PostgresLocator::features())?;
+
+    // Get the parts of our locator.
+    let url = locator.url.clone();
+    let table_name = locator.table_name.clone();
+
+    // Look up the arguments we'll need.
+    let schema = shared_args.schema();
+
+    // Convert our schema to a native PostgreSQL schema.
+    let pg_create_table =
+        PgCreateTable::from_name_and_columns(table_name.clone(), &schema.columns)?;
+
+    // Generate SQL for query.
+    let mut sql_bytes: Vec<u8> = vec![];
+    pg_create_table.write_count_sql(&mut sql_bytes, &source_args)?;
+    let sql = String::from_utf8(sql_bytes).expect("should always be UTF-8");
+    debug!(ctx.log(), "count SQL: {}", sql);
+
+    // Run our query.
+    let mut conn = connect(ctx.clone(), url).await?;
+    let stmt = conn.prepare(&sql).compat().await?;
+    let rows = conn
+        .query(&stmt, &[])
+        .collect()
+        .compat()
+        .await
+        .context("error running count query")?;
+    if rows.len() != 1 {
+        Err(format_err!(
+            "expected 1 row of count output, got {}",
+            rows.len(),
+        ))
+    } else {
+        let count: i64 = rows[0].get("count");
+        Ok(cast::usize(count).context("count out of range")?)
+    }
+}

--- a/dbcrossbarlib/src/drivers/postgres/mod.rs
+++ b/dbcrossbarlib/src/drivers/postgres/mod.rs
@@ -201,16 +201,16 @@ impl LocatorStatic for PostgresLocator {
 
     fn features() -> Features {
         Features {
-            locator: LocatorFeatures::SCHEMA
-                | LocatorFeatures::LOCAL_DATA
-                | LocatorFeatures::WRITE_LOCAL_DATA,
-            write_schema_if_exists: IfExistsFeatures::empty(),
-            source_args: SourceArgumentsFeatures::WHERE_CLAUSE,
-            dest_args: DestinationArgumentsFeatures::empty(),
-            dest_if_exists: IfExistsFeatures::OVERWRITE
-                | IfExistsFeatures::APPEND
-                | IfExistsFeatures::ERROR
-                | IfExistsFeatures::UPSERT,
+            locator: LocatorFeatures::Schema
+                | LocatorFeatures::LocalData
+                | LocatorFeatures::WriteLocalData,
+            write_schema_if_exists: EnumSet::empty(),
+            source_args: SourceArgumentsFeatures::WhereClause.into(),
+            dest_args: EnumSet::empty(),
+            dest_if_exists: IfExistsFeatures::Overwrite
+                | IfExistsFeatures::Append
+                | IfExistsFeatures::Error
+                | IfExistsFeatures::Upsert,
             _placeholder: (),
         }
     }

--- a/dbcrossbarlib/src/drivers/postgres/mod.rs
+++ b/dbcrossbarlib/src/drivers/postgres/mod.rs
@@ -17,10 +17,12 @@ use crate::common::*;
 use crate::drivers::postgres_shared::PgCreateTable;
 
 pub mod citus;
+mod count;
 mod csv_to_binary;
 mod local_data;
 mod write_local_data;
 
+use self::count::count_helper;
 use self::local_data::local_data_helper;
 use self::write_local_data::write_local_data_helper;
 
@@ -166,6 +168,15 @@ impl Locator for PostgresLocator {
         .boxed()
     }
 
+    fn count(
+        &self,
+        ctx: Context,
+        shared_args: SharedArguments<Unverified>,
+        source_args: SourceArguments<Unverified>,
+    ) -> BoxFuture<usize> {
+        count_helper(ctx, self.to_owned(), shared_args, source_args).boxed()
+    }
+
     fn local_data(
         &self,
         ctx: Context,
@@ -203,7 +214,8 @@ impl LocatorStatic for PostgresLocator {
         Features {
             locator: LocatorFeatures::Schema
                 | LocatorFeatures::LocalData
-                | LocatorFeatures::WriteLocalData,
+                | LocatorFeatures::WriteLocalData
+                | LocatorFeatures::Count,
             write_schema_if_exists: EnumSet::empty(),
             source_args: SourceArgumentsFeatures::WhereClause.into(),
             dest_args: EnumSet::empty(),

--- a/dbcrossbarlib/src/drivers/postgres_shared/table.rs
+++ b/dbcrossbarlib/src/drivers/postgres_shared/table.rs
@@ -143,6 +143,20 @@ impl PgCreateTable {
         }
         Ok(())
     }
+
+    /// Write a `SELECT COUNT(*) ...` statement for this table.
+    pub(crate) fn write_count_sql(
+        &self,
+        f: &mut dyn Write,
+        source_args: &SourceArguments<Verified>,
+    ) -> Result<()> {
+        writeln!(f, "SELECT COUNT(*)")?;
+        writeln!(f, " FROM {}", TableName(&self.name))?;
+        if let Some(where_clause) = source_args.where_clause() {
+            writeln!(f, " WHERE ({})", where_clause)?;
+        }
+        Ok(())
+    }
 }
 
 impl fmt::Display for PgCreateTable {

--- a/dbcrossbarlib/src/drivers/postgres_sql/mod.rs
+++ b/dbcrossbarlib/src/drivers/postgres_sql/mod.rs
@@ -55,11 +55,11 @@ impl LocatorStatic for PostgresSqlLocator {
 
     fn features() -> Features {
         Features {
-            locator: LocatorFeatures::SCHEMA | LocatorFeatures::WRITE_SCHEMA,
+            locator: LocatorFeatures::Schema | LocatorFeatures::WriteSchema,
             write_schema_if_exists: IfExistsFeatures::no_append(),
-            source_args: SourceArgumentsFeatures::empty(),
-            dest_args: DestinationArgumentsFeatures::empty(),
-            dest_if_exists: IfExistsFeatures::empty(),
+            source_args: EnumSet::empty(),
+            dest_args: EnumSet::empty(),
+            dest_if_exists: EnumSet::empty(),
             _placeholder: (),
         }
     }

--- a/dbcrossbarlib/src/drivers/redshift/mod.rs
+++ b/dbcrossbarlib/src/drivers/redshift/mod.rs
@@ -130,14 +130,14 @@ impl LocatorStatic for RedshiftLocator {
 
     fn features() -> Features {
         Features {
-            locator: LocatorFeatures::SCHEMA
-                | LocatorFeatures::LOCAL_DATA
-                | LocatorFeatures::WRITE_LOCAL_DATA,
-            write_schema_if_exists: IfExistsFeatures::empty(),
-            source_args: SourceArgumentsFeatures::DRIVER_ARGS
-                | SourceArgumentsFeatures::WHERE_CLAUSE,
-            dest_args: DestinationArgumentsFeatures::DRIVER_ARGS,
-            dest_if_exists: IfExistsFeatures::OVERWRITE | IfExistsFeatures::APPEND,
+            locator: LocatorFeatures::Schema
+                | LocatorFeatures::LocalData
+                | LocatorFeatures::WriteLocalData,
+            write_schema_if_exists: EnumSet::empty(),
+            source_args: SourceArgumentsFeatures::DriverArgs
+                | SourceArgumentsFeatures::WhereClause,
+            dest_args: DestinationArgumentsFeatures::DriverArgs.into(),
+            dest_if_exists: IfExistsFeatures::Overwrite | IfExistsFeatures::Append,
             _placeholder: (),
         }
     }

--- a/dbcrossbarlib/src/drivers/s3/mod.rs
+++ b/dbcrossbarlib/src/drivers/s3/mod.rs
@@ -115,11 +115,11 @@ impl LocatorStatic for S3Locator {
 
     fn features() -> Features {
         Features {
-            locator: LocatorFeatures::LOCAL_DATA | LocatorFeatures::WRITE_LOCAL_DATA,
-            write_schema_if_exists: IfExistsFeatures::empty(),
-            source_args: SourceArgumentsFeatures::empty(),
-            dest_args: DestinationArgumentsFeatures::empty(),
-            dest_if_exists: IfExistsFeatures::OVERWRITE,
+            locator: LocatorFeatures::LocalData | LocatorFeatures::WriteLocalData,
+            write_schema_if_exists: EnumSet::empty(),
+            source_args: EnumSet::empty(),
+            dest_args: EnumSet::empty(),
+            dest_if_exists: IfExistsFeatures::Overwrite.into(),
             _placeholder: (),
         }
     }

--- a/dbcrossbarlib/src/lib.rs
+++ b/dbcrossbarlib/src/lib.rs
@@ -61,6 +61,7 @@ pub use tokio_glue::{run_futures_with_runtime, ConsumeWithParallelism};
 #[allow(unused_imports)]
 pub(crate) mod common {
     pub(crate) use bytes::BytesMut;
+    pub(crate) use enumset::{EnumSet, EnumSetType};
     pub(crate) use failure::{format_err, ResultExt};
     pub(crate) use futures::{
         compat::{Compat01As03, Future01CompatExt},

--- a/dbcrossbarlib/src/locator.rs
+++ b/dbcrossbarlib/src/locator.rs
@@ -65,6 +65,17 @@ pub trait Locator: fmt::Debug + fmt::Display + Send + Sync + 'static {
         async move { Err(err) }.boxed()
     }
 
+    /// Count the records specified by this locator.
+    fn count(
+        &self,
+        _ctx: Context,
+        _shared_args: SharedArguments<Unverified>,
+        _source_args: SourceArguments<Unverified>,
+    ) -> BoxFuture<usize> {
+        let err = format_err!("cannot count records at {}", self);
+        async move { Err(err) }.boxed()
+    }
+
     /// If this locator can be used as a local data source, return a stream of
     /// CSV streams. This function type is bit hairy:
     ///
@@ -204,6 +215,7 @@ pub enum LocatorFeatures {
     WriteSchema,
     LocalData,
     WriteLocalData,
+    Count,
 }
 
 /// A collection of all the features supported by a given driver. This is
@@ -241,6 +253,12 @@ impl fmt::Display for Features {
         if self.locator.contains(LocatorFeatures::WriteSchema) {
             writeln!(f, "- conv TO:")?;
             writeln!(f, "  {}", self.write_schema_if_exists.display())?;
+        }
+        if self.locator.contains(LocatorFeatures::Count) {
+            writeln!(f, "- count")?;
+            if !self.source_args.is_empty() {
+                writeln!(f, "  {}", self.source_args.display())?;
+            }
         }
         if self.locator.contains(LocatorFeatures::LocalData) {
             writeln!(f, "- cp FROM:")?;


### PR DESCRIPTION
This can be used to count the rows associated with either a BigQuery or PostgreSQL locator. (In theory, we could add a portable fallback which downloaded data, converted it to CSV, and counted the rows manually, but we don't have that yet. And it would be slower, anyways.)

We also convert from the `bitflags` crate to the less error-prone `enumset` crate that we've had good results with elsewhere. `bitflags` mostly useful when you need C-level compatibility or when you're using an embedded system.