### PR TITLE
Add a `--max-streams` flag to control max concurrency

### DIFF
--- a/dbcrossbar/src/cmd/count.rs
+++ b/dbcrossbar/src/cmd/count.rs
@@ -46,9 +46,10 @@ pub(crate) async fn run(ctx: Context, opt: Opt) -> Result<()> {
             })
     }?;
 
-    // Build our shared arguments.
+    // Build our shared arguments. Specify 1 for `max_streams` until we actually
+    // implement local counting.
     let temporary_storage = TemporaryStorage::new(opt.temporaries.clone());
-    let shared_args = SharedArguments::new(schema, temporary_storage);
+    let shared_args = SharedArguments::new(schema, temporary_storage, 1);
 
     // Build our source arguments.
     let from_args = DriverArguments::from_cli_args(&opt.from_args)?;

--- a/dbcrossbar/tests/tests.rs
+++ b/dbcrossbar/tests/tests.rs
@@ -262,6 +262,7 @@ fn cp_csv_to_postgres_to_gs_to_csv() {
         .args(&[
             "cp",
             "--if-exists=overwrite",
+            "--max-streams=8",
             &format!("--schema=postgres-sql:{}", schema.display()),
             &format!("csv:{}", src.display()),
             &pg_table,

--- a/dbcrossbarlib/src/args.rs
+++ b/dbcrossbarlib/src/args.rs
@@ -60,18 +60,36 @@ pub struct SharedArguments<S: ArgumentState> {
     /// the transfer.
     temporary_storage: TemporaryStorage,
 
+    /// How many streams should we process at once?
+    max_streams: usize,
+
     /// We need to include a reference to `ArgumentState` somewhere, so use a
     /// 0-byte phantom value.
     _phantom: PhantomData<S>,
 }
 
+impl<S: ArgumentState> SharedArguments<S> {
+    /// How many concurrent data streams should we attempt to process at once?
+    ///
+    /// This is available even for unvalidated arguments because it's used by
+    /// our top-level code as well as some of the individual drivers.
+    pub fn max_streams(&self) -> usize {
+        self.max_streams
+    }
+}
+
 // These methods are only available in the `Unverified` state.
 impl SharedArguments<Unverified> {
     /// Create a new `SharedArguments` structure.
-    pub fn new(schema: Table, temporary_storage: TemporaryStorage) -> Self {
+    pub fn new(
+        schema: Table,
+        temporary_storage: TemporaryStorage,
+        max_streams: usize,
+    ) -> Self {
         Self {
             schema,
             temporary_storage,
+            max_streams,
             _phantom: PhantomData,
         }
     }
@@ -86,6 +104,7 @@ impl SharedArguments<Unverified> {
         Ok(SharedArguments {
             schema: self.schema,
             temporary_storage: self.temporary_storage,
+            max_streams: self.max_streams,
             _phantom: PhantomData,
         })
     }

--- a/dbcrossbarlib/src/drivers/bigquery/write_local_data.rs
+++ b/dbcrossbarlib/src/drivers/bigquery/write_local_data.rs
@@ -29,7 +29,9 @@ pub(crate) async fn write_local_data_helper(
     // TODO: This duplicates our top-level `cp` code and we need to implement
     // the same rules for picking a good argument to `consume_with_parallelism`
     // and not just hard code our parallelism.
-    result_stream.consume_with_parallelism(shared_args_v.max_streams()).await?;
+    result_stream
+        .consume_with_parallelism(shared_args_v.max_streams())
+        .await?;
 
     // Load from gs:// to BigQuery.
     let from_temp_ctx = ctx.child(o!("from_temp" => gs_temp.to_string()));

--- a/dbcrossbarlib/src/drivers/bigquery/write_local_data.rs
+++ b/dbcrossbarlib/src/drivers/bigquery/write_local_data.rs
@@ -29,7 +29,7 @@ pub(crate) async fn write_local_data_helper(
     // TODO: This duplicates our top-level `cp` code and we need to implement
     // the same rules for picking a good argument to `consume_with_parallelism`
     // and not just hard code our parallelism.
-    result_stream.consume_with_parallelism(4).await?;
+    result_stream.consume_with_parallelism(shared_args_v.max_streams()).await?;
 
     // Load from gs:// to BigQuery.
     let from_temp_ctx = ctx.child(o!("from_temp" => gs_temp.to_string()));

--- a/dbcrossbarlib/src/drivers/redshift/write_local_data.rs
+++ b/dbcrossbarlib/src/drivers/redshift/write_local_data.rs
@@ -30,7 +30,7 @@ pub(crate) async fn write_local_data_helper(
     // TODO: This duplicates our top-level `cp` code and we need to implement
     // the same rules for picking a good argument to `consume_with_parallelism`
     // and not just hard code our parallelism.
-    result_stream.consume_with_parallelism(4).await?;
+    result_stream.consume_with_parallelism(shared_args_v.max_streams()).await?;
 
     // Load from s3:// to Redshift.
     let from_temp_ctx = ctx.child(o!("from_temp" => s3_temp.to_string()));

--- a/dbcrossbarlib/src/drivers/redshift/write_local_data.rs
+++ b/dbcrossbarlib/src/drivers/redshift/write_local_data.rs
@@ -30,7 +30,9 @@ pub(crate) async fn write_local_data_helper(
     // TODO: This duplicates our top-level `cp` code and we need to implement
     // the same rules for picking a good argument to `consume_with_parallelism`
     // and not just hard code our parallelism.
-    result_stream.consume_with_parallelism(shared_args_v.max_streams()).await?;
+    result_stream
+        .consume_with_parallelism(shared_args_v.max_streams())
+        .await?;
 
     // Load from s3:// to Redshift.
     let from_temp_ctx = ctx.child(o!("from_temp" => s3_temp.to_string()));


### PR DESCRIPTION
This will be ignored in certain situations, and it may require an
unreasonable amount of RAM to work with GCloud sources, because copying
from GCloud using the Google CLI tools can use gigabytes of RAM.