### PR TITLE
WIP: Update for Rust stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
 - linux
 - osx
 rust:
-- nightly-2019-09-05
+- stable
 services:
 - docker
 before_script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile for building static release binaries using musl-libc.
 
-FROM ekidd/rust-musl-builder:nightly-2019-09-05-openssl11
+FROM ekidd/rust-musl-builder:stable-openssl11
 
 # We need to add the source code to the image because `rust-musl-builder`
 # assumes a UID of 1000, but TravisCI has switched to 2000.

--- a/dbcrossbarlib/src/concat.rs
+++ b/dbcrossbarlib/src/concat.rs
@@ -124,11 +124,8 @@ fn strip_csv_header(
                 }
                 Ok((None, _rest_of_stream)) => {
                     trace!(worker_ctx.log(), "end of stream");
-                    return send_err(
-                        sender,
-                        format_err!("end of CSV file while reading headers"),
-                    )
-                    .await;
+                    let err = format_err!("end of CSV file while reading headers");
+                    return send_err(sender, err).await;
                 }
                 Ok((Some(bytes), rest_of_stream)) => {
                     stream = rest_of_stream;

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly-2019-09-05
+stable


### PR DESCRIPTION
`dbcrossbar` currently requires Rust `nightly-2019-09-05`, because it relies on a minor `rustc` bug that was fixed shortly after that point.

- [x] Fix `format_err!` issue.
- [ ] Fix `pg_client.execute` issue.
  - Option 1: Backport https://github.com/sfackler/rust-postgres/pull/477 to `tokio-postgres` to obsolete 0.4.0-rc.2? This is only useful if upstream would be willing to cut an "already obsolete" release just for us.
  - Option 2: Update to `tokio-postgres` 0.5.0-alpha.1 **and** `tokio` 0.2.0-*? The latter is planned for next year, and it requires coordinating multiple dependencies and changing a lot of code. Not a good use of my time right now. :-/
  - Option 3: Continue to require a specific nightly Rust for `dbcrossbar`.

The takeaways from this effort:

- All of our `async` Rust that _doesn't_ rely on `tokio-postgres` can be updated to stable Rust whenever we want.
- The error messages for `async` still require significant Rust knowledge to interpret, pending promised improvements in newer Rust releases. So there's a strong argument that we should continue to limit our use of `async` Rust to a small number of infrastruture projects that would really benefit from it.

### Background

_For more background on these changes, here's a discussion of the `format_err!` fix._

Rust 0.39.0 is the first stable Rust with `async` support, but the
compiler error messages aren't quite there yet. Here's an example of one
error that takes some low-level Rust knowledge to interpret:

    error[E0277]: `*mut (dyn std::ops::Fn() + 'static)` cannot be shared between threads safely
       --> dbcrossbarlib/src/concat.rs:179:29
        |
    179 |     ctx.spawn_worker(worker.boxed().compat());
        |                             ^^^^^ `*mut (dyn std::ops::Fn() + 'static)` cannot be shared between threads safely
        |
        = help: within `core::fmt::Void`, the trait `std::marker::Sync` is not implemented for `*mut (dyn std::ops::Fn() + 'static)`
        = note: required because it appears within the type `std::marker::PhantomData<*mut (dyn std::ops::Fn() + 'static)>`
        = note: required because it appears within the type `core::fmt::Void`
        = note: required because of the requirements on the impl of `std::marker::Send` for `&core::fmt::Void`
        = note: required because it appears within the type `std::fmt::ArgumentV1<'_>`

Here, we have a `Future` type, and we're trying to stick it in
`Box`. (In other words, we want to store the future's runtime state on
the heap.) When we try to call the method `.boxed()` on it, we get this
error.

We get an error about not being able to share `worker` (our future)
between threads safely, because some type "`*mut (dyn std::ops::Fn() +
'static)` cannot be shared between threads safely", because
"`std::marker::Sync` is not implemented for `*mut (dyn std::ops::Fn() +
'static)`".

Let's translate that a bit.

Here, `Sync` is a Rust trait which means "this value may be safely seen
by two threads at once, and we promise the world won't burn down."
Normally, the Rust compiler automatically decides what structs and
closures could implement the `Sync` trait and defines it automatically
whenever it can.

So why does Rust want that particular type to implement `Sync`? Well,
it's "required because of the requirements on the impl of
`std::marker::Send` for `&core::fmt::Void`".

`Send` is another magic trait which means "I don't promise it's OK for
two threads to _see_ this value at once, but you can safely send it
between threads." Again, Rust defines `Send` for us automatically.

Which brings us to the remaining key points:

1. For any type `T`, the type `&T` (reference to `T`) is only `Send` if
   `T` is `Sync`. That's because once we create a reference and send it
   to another thread, more than one thread might be able to see our `T`.
2. When we call `worker.boxed()`, it tries to take all the internal
   state of our future and turn it into a `Box<..>` that we can send
   between threads. So any local variables _anywhere_ inside the various
   `async` functions called by that future need to be `Send`, which
   implies that any pointers need to be pointing to `Sync` objects.
3. Some of the machinery inside the `format!` macro isn't `Sync`.

So what we're looking for is a very specific kind of thing: a `format!`
macro that keeps some machinery alive _across_ an `await`. Grepping
through the source code reveals this:

    return send_err(
        sender,
        format_err!("end of CSV file while reading headers"),
    )
    .await;

It's time for our final key insight:

4. Rust _always_ keeps temporary variables alive until the "end of the
   line", which is generally what you want.

This means that the `format_err!` above creates non-`Send` temporary
variables that try to stay alive over the `await`. This forces Rust to
store those temporary values inside the `Future`, making the whole
future non-`Send`.

The fix is ridiculously simple: Just put `format_err!` on its own line:

    let err = format_err!("end of CSV file while reading headers");
    return send_err(sender, err).await;

Voilà! Now our `Future` is `Send` (and a bit smaller), and we can call
`.boxed()` on it.

There's no reason a future version of the Rust compiler won't be able to
produce an error message that explains all of this for the user, and
actually highlights the offending line. But it's a documented problem
that the error messages for `async` are still weak in the 1.39.0's
stable `async` MVP.

But this kind of error message is why Faraday tries to limit the use of
`async` Rust to a very small number of infrastructure projects that
benefit significally from it.