### PR TITLE
Support exporting BigQuery `RECORD` columns as JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bigml"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bigml_derive 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -513,7 +513,7 @@ name = "dbcrossbarlib"
 version = "0.2.8"
 dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bigml 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bigml 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2688,7 +2688,7 @@ dependencies = [
 "checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
-"checksum bigml 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "149eb00733b3e89979a76e88d7df36571483b18c7c468ae177d648a0e52be495"
+"checksum bigml 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "93a64767bc0eb36045c1cc7fef39c9e37d1f69e08b5d86a4e821c69a875a2679"
 "checksum bigml_derive 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4b3682b57e469b57695394976ea2b17716b3fd638cce0bd1e02d3ae5f3a3fa43"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum blake2b_simd 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b83b7baab1e671718d78204225800d6b170e648188ac7dc992e9d6bddf87d0c0"

--- a/dbcrossbar/fixtures/bigquery_schema.json
+++ b/dbcrossbar/fixtures/bigquery_schema.json
@@ -7,7 +7,7 @@
   {
     "name": "test_not_null",
     "type": "STRING",
-    "mode": "NULLABLE"
+    "mode": "REQUIRED"
   },
   {
     "name": "test_bool",
@@ -133,5 +133,36 @@
     "name": "test_uuid_array",
     "type": "STRING",
     "mode": "REPEATED"
+  },
+  {
+    "name": "record",
+    "type": "RECORD",
+    "mode": "NULLABLE",
+    "fields": [
+      {
+        "name": "nested",
+        "type": "RECORD",
+        "mode": "REQUIRED",
+        "fields": [
+          {
+            "name": "i1",
+            "type": "INT64",
+            "mode": "NULLABLE"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "records",
+    "type": "RECORD",
+    "mode": "REPEATED",
+    "fields": [
+      {
+        "name": "i2",
+        "type": "INT64",
+        "mode": "NULLABLE"
+      }
+    ]
   }
 ]

--- a/dbcrossbar/fixtures/bigquery_schema_converted.sql
+++ b/dbcrossbar/fixtures/bigquery_schema_converted.sql
@@ -1,6 +1,6 @@
 CREATE TABLE "unnamed" (
     "test_null" text,
-    "test_not_null" text,
+    "test_not_null" text NOT NULL,
     "test_bool" boolean,
     "test_bool_array" boolean[],
     "test_date" date,
@@ -25,5 +25,7 @@ CREATE TABLE "unnamed" (
     "test_timestamp_with_time_zone" timestamp with time zone,
     "test_timestamp_with_time_zone_array" timestamp with time zone[],
     "test_uuid" text,
-    "test_uuid_array" text[]
+    "test_uuid_array" text[],
+    "record" jsonb,
+    "records" jsonb
 );

--- a/dbcrossbarlib/Cargo.toml
+++ b/dbcrossbarlib/Cargo.toml
@@ -21,7 +21,7 @@ slog-term = "2.4.0"
 
 [dependencies]
 base64 = "0.11.0"
-bigml = "0.4.2"
+bigml = "0.4.4"
 byteorder = "1.3.1"
 bytes = "0.4.11"
 cast = "0.2.2"

--- a/dbcrossbarlib/src/drivers/bigquery/schema.rs
+++ b/dbcrossbarlib/src/drivers/bigquery/schema.rs
@@ -1,11 +1,8 @@
 //! Implementation of `schema`.
 
-use std::process::{Command, Stdio};
-use tokio_process::CommandExt;
-
 use super::BigQueryLocator;
 use crate::common::*;
-use crate::drivers::bigquery_shared::{BqColumn, BqTable};
+use crate::drivers::bigquery_shared::BqTable;
 use crate::schema::Table;
 
 /// Implementation of `schema`, but as a real `async` function.
@@ -13,36 +10,6 @@ pub(crate) async fn schema_helper(
     ctx: Context,
     source: BigQueryLocator,
 ) -> Result<Option<Table>> {
-    let output = Command::new("bq")
-        .args(&[
-            "show",
-            "--headless",
-            "--schema",
-            "--format=json",
-            &format!("--project_id={}", source.project()),
-            &source.table_name.to_string(),
-        ])
-        .stderr(Stdio::inherit())
-        .output_async()
-        .compat()
-        .await
-        .context("error running `bq show --schema`")?;
-    if !output.status.success() {
-        return Err(format_err!(
-            "`bq show --schema` failed with {}",
-            output.status,
-        ));
-    }
-    debug!(
-        ctx.log(),
-        "BigQuery schema: {}",
-        String::from_utf8_lossy(&output.stdout).trim(),
-    );
-    let columns: Vec<BqColumn> = serde_json::from_slice(&output.stdout)
-        .context("error parsing BigQuery schema")?;
-    let table = BqTable {
-        name: source.table_name.clone(),
-        columns,
-    };
-    Ok(Some(table.to_table()?))
+    let bq_table = BqTable::read_from_table(&ctx, &source.table_name).await?;
+    Ok(Some(bq_table.to_table()?))
 }

--- a/dbcrossbarlib/src/drivers/bigquery_shared/column.rs
+++ b/dbcrossbarlib/src/drivers/bigquery_shared/column.rs
@@ -378,9 +378,12 @@ return "#,
                 write!(f, "ST_ASGEOJSON({ident}) AS {ident}", ident = ident)?;
             }
 
-            BqNonArrayDataType::Struct(_) => {
-                // TODO: Check struct for duplicate or unnamed keys.
-                write!(f, "TO_JSON_STRING({ident}) AS {ident}", ident = ident)?;
+            struct_ty @ BqNonArrayDataType::Struct(_) => {
+                if struct_ty.is_json_safe() {
+                    write!(f, "TO_JSON_STRING({ident}) AS {ident}", ident = ident)?;
+                } else {
+                    return Err(format_err!("cannot serialize {} as JSON", struct_ty));
+                }
             }
 
             BqNonArrayDataType::Timestamp => {

--- a/dbcrossbarlib/src/drivers/bigquery_shared/data_type.rs
+++ b/dbcrossbarlib/src/drivers/bigquery_shared/data_type.rs
@@ -1,9 +1,9 @@
 //! Data types supported BigQuery.
 
 use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize, Serializer};
-use std::{fmt, result};
+use std::{borrow::Cow, fmt, result};
 
-use super::column::Mode;
+use super::column::{BqColumn, Mode};
 use crate::common::*;
 use crate::schema::{DataType, Srid};
 use crate::separator::Separator;
@@ -86,6 +86,27 @@ impl BqDataType {
         }
     }
 
+    /// Convert this `BqDataType` to `DataType`.
+    pub(crate) fn to_data_type(&self) -> Result<DataType> {
+        match self {
+            // This is controversial philosophical decision, but Seamus argues
+            // strongly that nobody ever wants to see `jsonb[]` or
+            // `ARRAY<STRING>` where the `STRING` contains serialized JSON. So
+            // we turn arrays of JSON values into JSON array values, yielding
+            // `jsonb` or a `STRING` containing a serialized JSON array value.
+            //
+            // We special-case this _here_ because BigQuery uses this pattern a
+            // lot. Other database drivers should probably to something similar
+            // when converting native types to portable types, but it's really
+            // rare to see `jsonb[]` in a real-world PostgreSQL database. Or I
+            // suppose we could apply this simplification directly on the
+            // portable `DataType` at some point.
+            BqDataType::Array(BqNonArrayDataType::Struct(_)) => Ok(DataType::Json),
+            BqDataType::Array(ty) => Ok(DataType::Array(Box::new(ty.to_data_type()?))),
+            BqDataType::NonArray(ty) => ty.to_data_type(),
+        }
+    }
+
     /// Can BigQuery import this type from a CSV file?
     pub(crate) fn bigquery_can_import_from_csv(&self) -> bool {
         match self {
@@ -130,6 +151,83 @@ impl Serialize for BqDataType {
     }
 }
 
+/// Either a regular BigQuery non-array data type or `"RECORD"`, which appears
+/// as a placeholder in BigQuery schema files, but it really a placeholder
+/// telling us to construct a `STRUCT` type using the column's `"fields"`.
+///
+/// This is marked `pub` instead of `pub(crate)` because of limitations in
+/// `rust-peg`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum BqRecordOrNonArrayDataType {
+    Record,
+    DataType(BqNonArrayDataType),
+}
+
+impl BqRecordOrNonArrayDataType {
+    pub(crate) fn to_bq_data_type(
+        &self,
+        mode: Mode,
+        fields: &[BqColumn],
+    ) -> Result<BqDataType> {
+        let ty = self.to_bq_non_array_data_type(fields)?.into_owned();
+        match mode {
+            Mode::Repeated => Ok(BqDataType::Array(ty)),
+            Mode::Nullable | Mode::Required => Ok(BqDataType::NonArray(ty)),
+        }
+    }
+
+    /// Convert this to BigQuery `BqNonArrayDataType`.
+    pub(crate) fn to_bq_non_array_data_type(
+        &self,
+        fields: &[BqColumn],
+    ) -> Result<Cow<BqNonArrayDataType>> {
+        match self {
+            BqRecordOrNonArrayDataType::Record => {
+                let fields = fields
+                    .iter()
+                    .map(|f| f.to_struct_field())
+                    .collect::<Result<Vec<_>>>()?;
+                Ok(Cow::Owned(BqNonArrayDataType::Struct(fields)))
+            }
+            BqRecordOrNonArrayDataType::DataType(ty) => Ok(Cow::Borrowed(ty)),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for BqRecordOrNonArrayDataType {
+    fn deserialize<D>(deserializer: D) -> result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        let parsed = grammar::record_or_non_array_data_type(&raw).map_err(|err| {
+            D::Error::custom(format!(
+                "error parsing BigQuery data type {:?}: {}",
+                raw, err
+            ))
+        })?;
+        Ok(parsed)
+    }
+}
+
+impl fmt::Display for BqRecordOrNonArrayDataType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BqRecordOrNonArrayDataType::Record => write!(f, "RECORD"),
+            BqRecordOrNonArrayDataType::DataType(ty) => write!(f, "{}", ty),
+        }
+    }
+}
+
+impl Serialize for BqRecordOrNonArrayDataType {
+    fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // Convert to a string and serialize that.
+        format!("{}", self).serialize(serializer)
+    }
+}
 /// Any type except `ARRAY` (which cannot be nested in another `ARRAY`).
 ///
 /// This should really be `pub(crate)`, see [BqDataType].
@@ -210,30 +308,22 @@ impl BqNonArrayDataType {
     }
 
     /// Convert this `BqNonArrayDataType` to a portable `DataType`.
-    pub(crate) fn to_data_type(&self, mode: Mode) -> Result<DataType> {
-        if mode == Mode::Repeated {
-            // I _think_ all values in arrays are always nullable.
-            Ok(DataType::Array(Box::new(
-                self.to_data_type(Mode::Nullable)?,
-            )))
-        } else {
-            match self {
-                BqNonArrayDataType::Bool => Ok(DataType::Bool),
-                BqNonArrayDataType::Date => Ok(DataType::Date),
-                BqNonArrayDataType::Numeric => Ok(DataType::Decimal),
-                BqNonArrayDataType::Float64 => Ok(DataType::Float64),
-                BqNonArrayDataType::Geography => Ok(DataType::GeoJson(Srid::wgs84())),
-                BqNonArrayDataType::Int64 => Ok(DataType::Int64),
-                BqNonArrayDataType::String => Ok(DataType::Text),
-                BqNonArrayDataType::Datetime => Ok(DataType::TimestampWithoutTimeZone),
-                BqNonArrayDataType::Timestamp => Ok(DataType::TimestampWithTimeZone),
-                BqNonArrayDataType::Bytes
-                | BqNonArrayDataType::Struct(_)
-                | BqNonArrayDataType::Time => Err(format_err!(
-                    "cannot convert {} to portable type (yet)",
-                    self
-                )),
-            }
+    pub(crate) fn to_data_type(&self) -> Result<DataType> {
+        match self {
+            BqNonArrayDataType::Bool => Ok(DataType::Bool),
+            BqNonArrayDataType::Date => Ok(DataType::Date),
+            BqNonArrayDataType::Numeric => Ok(DataType::Decimal),
+            BqNonArrayDataType::Float64 => Ok(DataType::Float64),
+            BqNonArrayDataType::Geography => Ok(DataType::GeoJson(Srid::wgs84())),
+            BqNonArrayDataType::Int64 => Ok(DataType::Int64),
+            BqNonArrayDataType::String => Ok(DataType::Text),
+            BqNonArrayDataType::Datetime => Ok(DataType::TimestampWithoutTimeZone),
+            BqNonArrayDataType::Struct(_) => Ok(DataType::Json),
+            BqNonArrayDataType::Timestamp => Ok(DataType::TimestampWithTimeZone),
+            BqNonArrayDataType::Bytes | BqNonArrayDataType::Time => Err(format_err!(
+                "cannot convert {} to portable type (yet)",
+                self,
+            )),
         }
     }
 }
@@ -297,9 +387,9 @@ impl Serialize for BqNonArrayDataType {
 pub struct BqStructField {
     /// An optional field name. BigQuery `STRUCT`s are basically tuples, but
     /// with optional names for each position in the tuple.
-    name: Option<String>,
+    pub(crate) name: Option<String>,
     /// The field type.
-    ty: BqDataType,
+    pub(crate) ty: BqDataType,
 }
 
 impl fmt::Display for BqStructField {

--- a/dbcrossbarlib/src/drivers/bigquery_shared/data_type.rustpeg
+++ b/dbcrossbarlib/src/drivers/bigquery_shared/data_type.rustpeg
@@ -5,7 +5,7 @@
 //!
 //! [peg]: https://github.com/kevinmehall/rust-peg
 
-use super::{BqDataType, BqNonArrayDataType, BqStructField};
+use super::{BqDataType, BqNonArrayDataType, BqRecordOrNonArrayDataType, BqStructField};
 
 pub data_type -> BqDataType
     = array_data_type
@@ -13,6 +13,10 @@ pub data_type -> BqDataType
 
 array_data_type -> BqDataType
     = "ARRAY<" ty:non_array_data_type ">" { BqDataType::Array(ty) }
+
+pub record_or_non_array_data_type -> BqRecordOrNonArrayDataType
+    = "RECORD" { BqRecordOrNonArrayDataType::Record }
+    / ty:non_array_data_type { BqRecordOrNonArrayDataType::DataType(ty) }
 
 pub non_array_data_type -> BqNonArrayDataType
     // BOOLEAN, FLOAT and INTEGER are undocumented but seen in `bq show --schema`

--- a/dbcrossbarlib/src/drivers/bigquery_shared/table.rs
+++ b/dbcrossbarlib/src/drivers/bigquery_shared/table.rs
@@ -7,7 +7,7 @@ use std::{
     io::Write,
 };
 
-use super::{BqColumn, ColumnBigQueryExt, Ident, Mode, TableName, Usage};
+use super::{BqColumn, ColumnBigQueryExt, Ident, TableName, Usage};
 use crate::common::*;
 use crate::schema::{Column, Table};
 use crate::uniquifier::Uniquifier;
@@ -135,7 +135,7 @@ impl BqTable {
         // it's not obvious how to `MERGE` on columns that might be `NULL`.
         // Until we have a solution that we like, fail with an error.
         for merge_key in &merge_keys {
-            if merge_key.mode != Mode::Required {
+            if !merge_key.can_be_merged_on() {
                 return Err(format_err!(
                     "BigQuery cannot upsert on {:?} because it is not REQUIRED (aka NOT NULL)",
                     merge_key.name,

--- a/dbcrossbarlib/src/drivers/gs/write_remote_data.rs
+++ b/dbcrossbarlib/src/drivers/gs/write_remote_data.rs
@@ -45,17 +45,24 @@ pub(crate) async fn write_remote_data_helper(
 
     // Construct a `BqTable` describing our source table.
     let source_table = BqTable::for_table_name_and_columns(
-        source_table_name,
+        source_table_name.clone(),
         &schema.columns,
         Usage::FinalTable,
     )?;
+
+    // Look up our _actual_ table schema, which we'll need to handle the finer
+    // details of exporting RECORDs and other things which aren't visible in the
+    // portable schema. We do something similar in PostgreSQL imports.
+    let mut real_source_table =
+        BqTable::read_from_table(&ctx, &source_table_name).await?;
+    real_source_table = real_source_table.aligned_with(&source_table)?;
 
     // We need to build a temporary export table.
     let temp_table_name = source_table
         .name()
         .temporary_table_name(&temporary_storage)?;
     let mut export_sql_data = vec![];
-    source_table.write_export_sql(&source_args, &mut export_sql_data)?;
+    real_source_table.write_export_sql(&source_args, &mut export_sql_data)?;
     let export_sql =
         String::from_utf8(export_sql_data).expect("should always be UTF-8");
     debug!(ctx.log(), "export SQL: {}", export_sql);


### PR DESCRIPTION
This PR adds support for `RECORD` type columns in BigQuery, which are essentially columns of type `STRUCT<...>`. But they appear in the BigQuery JSON schemas in an inconvenient way, so we have to go out of our way to handle them.

Note that we convert both `RECORD` and `REPEATED RECORD` fields into JSON, which means that (to put in PostgreSQL terms), we serialize `ARRAY<STRUCT<...>>` as `jsonb` containing a JSON array, and not as `jsonb[]`. This was done because @seamusabshere argued that nobody ever wants to see `jsonb[]`, but it involved some slightly non-orthogonal code in the BigQuery driver.

More and more pressure is building is building to implement a "shortcut" system that can handle more data representations than just CSV, but that involves some real thinking before we go there.

- [x] Handle `RECORD` in BigQuery schemas, and convert to the corresponding `STRUCT` type.
- [x] Export `RECORD` columns and `ARRAY<RECORD>` columns as JSON objects and JSON arrays of objects, respectively.
- [x] Only export "JSON-safe" `RECORD` columns with no duplicate keys.