### PR TITLE
bigquery: Export booleans as "t"/"f"

### DIFF
--- a/dbcrossbarlib/src/drivers/bigquery_shared/column.rs
+++ b/dbcrossbarlib/src/drivers/bigquery_shared/column.rs
@@ -315,13 +315,20 @@ return "#,
 
         match data_type {
             // We trust BigQuery to output these directly.
-            BqNonArrayDataType::Bool
-            | BqNonArrayDataType::Date
+            BqNonArrayDataType::Date
             | BqNonArrayDataType::Float64
             | BqNonArrayDataType::Int64
             | BqNonArrayDataType::Numeric
             | BqNonArrayDataType::String => {
                 write!(f, "{}", ident)?;
+            }
+
+            // BigQuery outputs "true" and "false" by default, but let's make it
+            // look like PostgreSQL, so that CSV import drivers don't get too
+            // confused. This particularly affects BigML CSV import, because it
+            // treats booleans as string values.
+            BqNonArrayDataType::Bool => {
+                write!(f, "IF({ident}, \"t\", \"f\") AS {ident}", ident = ident)?;
             }
 
             BqNonArrayDataType::Datetime => {


### PR DESCRIPTION
Historically, we have allows databases some flexibility in how they
exported Boolean values. PostgreSQL preferred "t"/"f", but BigQuery used
"true"/"false". This was generally safe because most databases have
smart boolean parsing.

But BigML CSV import maps booleans to CATEGORICAL values, which are
strings that must match exactly. So we need to standardize booleans on
t/f everywhere.

This is a "quick fix" patch that relies on existing test cases to make
sure that everything works. We will also need to add _new_ test cases to
ensure standardized representations of as many values as possible, and
strictly document our interchange CSV format. But that can wait.