### PR TITLE
Encapsulate `bq` and `gsutil` & speed up `--stream-size`

### DIFF
--- a/dbcrossbarlib/src/clouds/gcloud/bigquery.rs
+++ b/dbcrossbarlib/src/clouds/gcloud/bigquery.rs
@@ -1,0 +1,315 @@
+//! Interfaces to BigQuery.
+
+use serde::de::DeserializeOwned;
+use std::{fs::File, process::Stdio};
+use tempdir::TempDir;
+use tokio::process::Command;
+
+use crate::common::*;
+use crate::drivers::bigquery_shared::{
+    if_exists_to_bq_load_arg, BqColumn, BqTable, TableName,
+};
+use crate::tokio_glue::write_to_stdin;
+
+/// Run a query that should return a small number of records, and return them as
+/// a JSON string.
+async fn query_all_json(ctx: &Context, project: &str, sql: &str) -> Result<String> {
+    // Run our query.
+    debug!(ctx.log(), "running `bq query`");
+    let mut query_child = Command::new("bq")
+        // We'll pass the query on `stdin`.
+        .stdin(Stdio::piped())
+        // We'll read output from `stdout`.
+        .stdout(Stdio::piped())
+        // Run query with no output.
+        .args(&["query", "--headless", "--format=json", "--nouse_legacy_sql"])
+        .arg(format!("--project_id={}", project))
+        .spawn()
+        .context("error starting `bq query`")?;
+    write_to_stdin("bq query", &mut query_child, sql.as_bytes()).await?;
+    let mut child_stdout = query_child
+        .stdout
+        .take()
+        .expect("don't have stdout that we requested");
+    let mut output = vec![];
+    child_stdout
+        .read_to_end(&mut output)
+        .await
+        .context("error reading output from `bq query`")?;
+    let output = String::from_utf8(output)?;
+    debug!(ctx.log(), "bq count output: {}", output.trim());
+
+    let status = query_child.await.context("error running `bq query`")?;
+    if status.success() {
+        Ok(output)
+    } else {
+        Err(format_err!("`bq query` failed with {}", status))
+    }
+}
+
+/// Run a query that should return a small number of records, and deserialize them.
+pub(crate) async fn query_all<T>(
+    ctx: &Context,
+    project: &str,
+    sql: &str,
+) -> Result<Vec<T>>
+where
+    T: DeserializeOwned,
+{
+    let output = query_all_json(ctx, project, sql).await?;
+    // Parse our output.
+    Ok(serde_json::from_str::<Vec<T>>(&output)
+        .context("could not parse count output")?)
+}
+
+/// Run a query that should return exactly one record, and deserialize it.
+pub(crate) async fn query_one<T>(ctx: &Context, project: &str, sql: &str) -> Result<T>
+where
+    T: DeserializeOwned,
+{
+    let mut rows = query_all(ctx, project, sql).await?;
+    if rows.len() == 1 {
+        Ok(rows.remove(0))
+    } else {
+        Err(format_err!("expected 1 row, found {}", rows.len()))
+    }
+}
+
+/// Run an SQL query and save the results to a table.
+pub(crate) async fn query_to_table(
+    ctx: &Context,
+    project: &str,
+    sql: &str,
+    dest_table: &TableName,
+    if_exists: &IfExists,
+) -> Result<()> {
+    // Run our query.
+    debug!(ctx.log(), "running `bq query`");
+    let mut query_child = Command::new("bq")
+        // We'll pass the query on `stdin`.
+        .stdin(Stdio::piped())
+        // Throw away stdout so it doesn't corrupt our output.
+        .stdout(Stdio::null())
+        // Run query with no output.
+        .args(&[
+            "query",
+            "--headless",
+            "--format=none",
+            &format!("--destination_table={}", dest_table),
+            if_exists_to_bq_load_arg(&if_exists)?,
+            "--nouse_legacy_sql",
+            &format!("--project_id={}", project),
+        ])
+        .spawn()
+        .context("error starting `bq query`")?;
+    write_to_stdin("bq query", &mut query_child, sql.as_bytes()).await?;
+    let status = query_child.await.context("error running `bq query`")?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format_err!("`bq query` failed with {}", status))
+    }
+}
+
+/// Execute an SQL statement.
+pub(crate) async fn execute_sql(
+    ctx: &Context,
+    project: &str,
+    sql: &str,
+) -> Result<()> {
+    // Run our SQL.
+    debug!(ctx.log(), "running `bq query`");
+    let mut query_child = Command::new("bq")
+        // We'll pass the SQL on `stdin`.
+        .stdin(Stdio::piped())
+        // Throw away stdout so it doesn't corrupt our output.
+        .stdout(Stdio::null())
+        // Run SQL with no output.
+        .args(&[
+            "query",
+            "--headless",
+            "--format=none",
+            "--nouse_legacy_sql",
+            &format!("--project_id={}", project),
+        ])
+        .spawn()
+        .context("error starting `bq query`")?;
+    write_to_stdin("bq query", &mut query_child, sql.as_bytes()).await?;
+    let status = query_child.await.context("error running `bq query`")?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format_err!("`bq query` failed with {}", status))
+    }
+}
+
+/// Load data from `gs_url` into `dest_table`.
+pub(crate) async fn load(
+    ctx: &Context,
+    gs_url: &Url,
+    dest_table: &BqTable,
+    if_exists: &IfExists,
+) -> Result<()> {
+    // Write our schema to a temp file. This actually needs to be somewhere on
+    // disk, and `bq` uses various hueristics to detect that it's a file
+    // containing a schema, and not just a string with schema text. (Note this
+    // code is synchronous, but that's not a huge deal.)
+    //
+    // We use `use_temp` to decide whether to generate the final schema or a
+    // temporary schema that we'll fix later.
+    let tmp_dir = TempDir::new("bq_load")?;
+    let initial_schema_path = tmp_dir.path().join("schema.json");
+    let mut initial_schema_file = File::create(&initial_schema_path)?;
+    dest_table.write_json_schema(&mut initial_schema_file)?;
+
+    // Build and run a `bq load` command.
+    debug!(ctx.log(), "running `bq load`");
+    let load_child = Command::new("bq")
+        // These arguments can all be represented as UTF-8 `&str`.
+        .args(&[
+            "load",
+            "--headless",
+            "--skip_leading_rows=1",
+            &format!("--project_id={}", dest_table.name().project()),
+            if_exists_to_bq_load_arg(&if_exists)?,
+            &dest_table.name().to_string(),
+            gs_url.as_str(),
+        ])
+        // Throw away stdout so it doesn't corrupt our output.
+        .stdout(Stdio::null())
+        // This argument is a path, and so it might contain non-UTF-8
+        // characters. We pass it separately because Rust won't allow us to
+        // create an array of mixed strings and paths.
+        .arg(&initial_schema_path)
+        .spawn()
+        .context("error starting `bq load`")?;
+    let status = load_child.await.context("error running `bq load`")?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format_err!("`bq load` failed with {}", status))
+    }
+}
+
+pub(crate) async fn create_table_if_not_exists(
+    ctx: &Context,
+    dest_table: &BqTable,
+) -> Result<()> {
+    debug!(ctx.log(), "making sure table {} exists", dest_table.name(),);
+    let tmp_dir = TempDir::new("bq_mk")?;
+    let dest_schema_path = tmp_dir.path().join("schema.json");
+    let mut dest_schema_file = File::create(&dest_schema_path)?;
+    dest_table.write_json_schema(&mut dest_schema_file)?;
+    let mk_child = Command::new("bq")
+        // Use `--force` to ignore existing tables.
+        .args(&[
+            "mk",
+            "--headless",
+            "--force",
+            "--schema",
+            // --project_id actually makes this fail for some reason.
+        ])
+        // Pass separately, because paths may not be UTF-8.
+        .arg(&dest_schema_path)
+        .arg(&dest_table.name().to_string())
+        // Throw away stdout so it doesn't corrupt our output.
+        .stdout(Stdio::null())
+        .spawn()
+        .context("error starting `bq mk`")?;
+    let status = mk_child.await.context("error running `bq mk`")?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format_err!("`bq mk` failed with {}", status))
+    }
+}
+
+/// Drop a table from BigQuery.
+pub(crate) async fn drop_table(ctx: &Context, table_name: &TableName) -> Result<()> {
+    // Delete temp table.
+    debug!(ctx.log(), "deleting import temp table: {}", table_name);
+    let rm_child = Command::new("bq")
+        .args(&[
+            "rm",
+            "--headless",
+            "-f",
+            "-t",
+            &format!("--project_id={}", table_name.project()),
+            &table_name.to_string(),
+        ])
+        // Throw away stdout so it doesn't corrupt our output.
+        .stdout(Stdio::null())
+        .spawn()
+        .context("error starting `bq rm`")?;
+    let status = rm_child.await.context("error running `bq rm`")?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format_err!("`bq rm` failed with {}", status))
+    }
+}
+
+/// Look up the schema of the specified table.
+pub(crate) async fn schema(ctx: &Context, name: &TableName) -> Result<BqTable> {
+    let project_id = format!("--project_id={}", name.project());
+    let output = Command::new("bq")
+        .args(&[
+            "show",
+            "--headless",
+            "--schema",
+            "--format=json",
+            &project_id,
+            &name.to_string(),
+        ])
+        .stderr(Stdio::inherit())
+        .output()
+        .await
+        .context("error running `bq show --schema`")?;
+    if !output.status.success() {
+        return Err(format_err!(
+            "`bq show --schema` failed with {}",
+            output.status,
+        ));
+    }
+    debug!(
+        ctx.log(),
+        "BigQuery schema: {}",
+        String::from_utf8_lossy(&output.stdout).trim(),
+    );
+    let columns: Vec<BqColumn> = serde_json::from_slice(&output.stdout)
+        .context("error parsing BigQuery schema")?;
+    Ok(BqTable {
+        name: name.to_owned(),
+        columns,
+    })
+}
+
+/// Extract a table from BigQuery to Google Cloud Storage.
+pub(crate) async fn extract(
+    ctx: &Context,
+    source_table: &TableName,
+    dest_gs_url: &Url,
+) -> Result<()> {
+    // Build and run a `bq extract` command.
+    debug!(ctx.log(), "running `bq extract`");
+    let extract_child = Command::new("bq")
+        // These arguments can all be represented as UTF-8 `&str`.
+        .args(&[
+            "extract",
+            "--headless",
+            "--destination_format=CSV",
+            &format!("--project_id={}", source_table.project()),
+            &source_table.to_string(),
+            &format!("{}/*.csv", dest_gs_url),
+        ])
+        // Throw away stdout so it doesn't corrupt our output.
+        .stdout(Stdio::null())
+        .spawn()
+        .context("error starting `bq extract`")?;
+    let status = extract_child.await.context("error running `bq extract`")?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format_err!("`bq extract` failed with {}", status))
+    }
+}

--- a/dbcrossbarlib/src/clouds/gcloud/mod.rs
+++ b/dbcrossbarlib/src/clouds/gcloud/mod.rs
@@ -1,3 +1,4 @@
 //! Interfaces to Google Cloud.
 
+pub(crate) mod bigquery;
 pub(crate) mod storage;

--- a/dbcrossbarlib/src/clouds/gcloud/mod.rs
+++ b/dbcrossbarlib/src/clouds/gcloud/mod.rs
@@ -1,0 +1,3 @@
+//! Interfaces to Google Cloud.
+
+pub(crate) mod storage;

--- a/dbcrossbarlib/src/clouds/gcloud/storage.rs
+++ b/dbcrossbarlib/src/clouds/gcloud/storage.rs
@@ -1,0 +1,120 @@
+//! Interfaces to Google Cloud Storage.
+
+use std::process::Stdio;
+use tokio::{io::BufReader, process::Command};
+
+use crate::common::*;
+use crate::tokio_glue::{copy_reader_to_stream, copy_stream_to_writer};
+
+/// List all the files at the specified `gs://` URL, recursively.
+pub(crate) async fn ls(
+    ctx: &Context,
+    url: &Url,
+) -> Result<impl Stream<Item = Result<String>> + Send + Unpin + 'static> {
+    // Build a URL to list.
+    let ls_url = if url.path().ends_with('/') {
+        url.join("**/*.csv")?
+    } else {
+        url.clone()
+    };
+
+    // Start a child process to list files at that URL.
+    //
+    // XXX - Shouldn't we be using `ls_url` below?
+    debug!(ctx.log(), "listing {}", ls_url);
+    let mut child = Command::new("gsutil")
+        .args(&["ls", url.as_str()])
+        .stdout(Stdio::piped())
+        .spawn()
+        .context("error running gsutil")?;
+    let child_stdout = child.stdout.take().expect("child should have stdout");
+    ctx.spawn_process(format!("gsutil ls {}", url), child);
+
+    // Parse `ls` output into lines, and convert into `CsvStream` values lazily
+    // in case there are a lot of CSV files we need to read.
+    let file_urls = BufReader::with_capacity(BUFFER_SIZE, child_stdout)
+        .lines()
+        .map_err(|e| format_err!("error reading gsutil output: {}", e));
+
+    Ok(file_urls)
+}
+
+/// Recursively delete a `gs://` directory without deleting the bucket.
+pub(crate) async fn rmdir(ctx: &Context, url: &Url) -> Result<()> {
+    // Delete all the files under `self.url`, but be careful not to
+    // delete the entire bucket. See `gsutil rm --help` for details.
+    debug!(ctx.log(), "deleting existing {}", url);
+    if !url.path().ends_with('/') {
+        return Err(format_err!(
+            "can only write to gs:// URL ending in '/', got {}",
+            url,
+        ));
+    }
+    let delete_url = url.join("**")?;
+    let status = Command::new("gsutil")
+        .args(&["rm", "-f", delete_url.as_str()])
+        // Throw away stdout so it doesn't corrupt our output.
+        .stdout(Stdio::null())
+        .status()
+        .await
+        .context("error running gsutil")?;
+    if !status.success() {
+        warn!(
+            ctx.log(),
+            "can't delete contents of {}, possibly because it doesn't exist", url,
+        );
+    }
+    Ok(())
+}
+
+/// Download the file at the specified URL as a stream.
+pub(crate) async fn download_file(
+    ctx: &Context,
+    file_url: &Url,
+) -> Result<BoxStream<BytesMut>> {
+    // Stream the file from the cloud.
+    debug!(ctx.log(), "streaming from {} using `gsutil cp`", file_url);
+    let mut child = Command::new("gsutil")
+        .args(&["cp", file_url.as_str(), "-"])
+        .stdout(Stdio::piped())
+        .spawn()
+        .context("error running gsutil")?;
+    let child_stdout = child.stdout.take().expect("child should have stdout");
+    let child_stdout = BufReader::with_capacity(BUFFER_SIZE, child_stdout);
+    let data = copy_reader_to_stream(ctx.clone(), child_stdout)?;
+    ctx.spawn_process(format!("gsutil cp {} -", file_url), child);
+    Ok(data.boxed())
+}
+
+/// Upload `data` as a file at `url`.
+pub(crate) async fn upload_file(
+    ctx: Context,
+    data: BoxStream<BytesMut>,
+    url: &Url,
+) -> Result<()> {
+    // Run `gsutil cp - $URL` as a background process.
+    debug!(ctx.log(), "uploading stream to gsutil");
+    let mut child = Command::new("gsutil")
+        .args(&["cp", "-", url.as_str()])
+        .stdin(Stdio::piped())
+        // Throw away stdout so it doesn't corrupt our output.
+        .stdout(Stdio::null())
+        .spawn()
+        .context("error running gsutil")?;
+    let child_stdin = child.stdin.take().expect("child should have stdin");
+
+    // Copy data to our child process.
+    copy_stream_to_writer(ctx.clone(), data, child_stdin)
+        .await
+        .context("error copying data to gsutil")?;
+
+    // Wait for `gsutil` to finish.
+    let status = child
+        .await
+        .with_context(|_| format!("error finishing upload to {}", url))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format_err!("gsutil returned error: {}", status))
+    }
+}

--- a/dbcrossbarlib/src/clouds/mod.rs
+++ b/dbcrossbarlib/src/clouds/mod.rs
@@ -1,0 +1,3 @@
+//! Interfaces to various clouds.
+
+pub(crate) mod gcloud;

--- a/dbcrossbarlib/src/drivers/bigquery/count.rs
+++ b/dbcrossbarlib/src/drivers/bigquery/count.rs
@@ -1,15 +1,13 @@
 //! Implementation of `count`, but as a real `async` function.
 
 use serde::Deserialize;
-use std::process::Stdio;
-use tokio::process::Command;
 
+use crate::clouds::gcloud::bigquery;
 use crate::common::*;
 use crate::drivers::{
     bigquery::BigQueryLocator,
     bigquery_shared::{BqTable, Usage},
 };
-use crate::tokio_glue::write_to_stdin;
 
 /// Implementation of `count`, but as a real `async` function.
 pub(crate) async fn count_helper(
@@ -39,51 +37,15 @@ pub(crate) async fn count_helper(
     debug!(ctx.log(), "count SQL: {}", count_sql);
 
     // Run our query.
-    debug!(ctx.log(), "running `bq query`");
-    let mut query_child = Command::new("bq")
-        // We'll pass the query on `stdin`.
-        .stdin(Stdio::piped())
-        // We'll read output from `stdout`.
-        .stdout(Stdio::piped())
-        // Run query with no output.
-        .args(&["query", "--headless", "--format=json", "--nouse_legacy_sql"])
-        .arg(format!("--project_id={}", locator.project()))
-        .spawn()
-        .context("error starting `bq query`")?;
-    write_to_stdin("bq query", &mut query_child, count_sql.as_bytes()).await?;
-    let mut child_stdout = query_child
-        .stdout
-        .take()
-        .expect("don't have stdout that we requested");
-    let mut output = vec![];
-    child_stdout
-        .read_to_end(&mut output)
-        .await
-        .context("error reading output from `bq query`")?;
-    let output = String::from_utf8(output)?;
-    debug!(ctx.log(), "bq count output: {}", output.trim());
-
-    let status = query_child.await.context("error running `bq query`")?;
-    if !status.success() {
-        return Err(format_err!("`bq query` failed with {}", status));
-    }
-
-    // Parse our output, and get the count.
     #[derive(Deserialize)]
     struct CountRow {
         count: String,
     }
-    let rows = serde_json::from_str::<Vec<CountRow>>(&output)
-        .context("could not parse count output")?;
-    if rows.len() != 1 {
-        Err(format_err!(
-            "expected 1 row of count output, got {}",
-            rows.len(),
-        ))
-    } else {
-        Ok(rows[0]
-            .count
-            .parse::<usize>()
-            .context("could not parse count output")?)
-    }
+    let count_str =
+        bigquery::query_one::<CountRow>(&ctx, locator.project(), &count_sql)
+            .await?
+            .count;
+    Ok(count_str
+        .parse::<usize>()
+        .context("could not parse count output")?)
 }

--- a/dbcrossbarlib/src/drivers/gs/local_data.rs
+++ b/dbcrossbarlib/src/drivers/gs/local_data.rs
@@ -1,12 +1,9 @@
 //! Reading data from Google Cloud Storage.
 
-use std::process::Stdio;
-use tokio::{io::BufReader, process::Command};
-
 use super::GsLocator;
+use crate::clouds::gcloud::storage;
 use crate::common::*;
 use crate::csv_stream::csv_stream_name;
-use crate::tokio_glue::copy_reader_to_stream;
 
 /// Implementation of `local_data`, but as a real `async` function.
 pub(crate) async fn local_data_helper(
@@ -19,30 +16,8 @@ pub(crate) async fn local_data_helper(
     let _source_args = source_args.verify(GsLocator::features())?;
     debug!(ctx.log(), "getting CSV files from {}", url);
 
-    // Build a URL to list.
-    let ls_url = if url.path().ends_with('/') {
-        url.join("**/*.csv")?
-    } else {
-        url.clone()
-    };
+    let file_urls = storage::ls(&ctx, &url).await?;
 
-    // Start a child process to list files at that URL.
-    //
-    // XXX - Shouldn't we be using `ls_url` below?
-    debug!(ctx.log(), "listing {}", ls_url);
-    let mut child = Command::new("gsutil")
-        .args(&["ls", url.as_str()])
-        .stdout(Stdio::piped())
-        .spawn()
-        .context("error running gsutil")?;
-    let child_stdout = child.stdout.take().expect("child should have stdout");
-    ctx.spawn_process(format!("gsutil ls {}", url), child);
-
-    // Parse `ls` output into lines, and convert into `CsvStream` values lazily
-    // in case there are a lot of CSV files we need to read.
-    let file_urls = BufReader::with_capacity(BUFFER_SIZE, child_stdout)
-        .lines()
-        .map_err(|e| format_err!("error reading gsutil output: {}", e));
     let csv_streams = file_urls.and_then(move |file_url| {
         let ctx = ctx.clone();
         let url = url.clone();
@@ -51,21 +26,13 @@ pub(crate) async fn local_data_helper(
             let name = csv_stream_name(url.as_str(), &file_url)?;
             let ctx =
                 ctx.child(o!("stream" => name.to_owned(), "url" => file_url.clone()));
-            debug!(ctx.log(), "streaming from {} using `gsutil cp`", file_url);
-            let mut child = Command::new("gsutil")
-                .args(&["cp", file_url.as_str(), "-"])
-                .stdout(Stdio::piped())
-                .spawn()
-                .context("error running gsutil")?;
-            let child_stdout = child.stdout.take().expect("child should have stdout");
-            let child_stdout = BufReader::with_capacity(BUFFER_SIZE, child_stdout);
-            let data = copy_reader_to_stream(ctx.clone(), child_stdout)?;
-            ctx.spawn_process(format!("gsutil cp {} -", file_url), child);
+            let file_url = Url::parse(&file_url)?;
+            let data = storage::download_file(&ctx, &file_url).await?;
 
             // Assemble everything into a CSV stream.
             Ok(CsvStream {
                 name: name.to_owned(),
-                data: data.boxed(),
+                data,
             })
         }
         .boxed()

--- a/dbcrossbarlib/src/drivers/gs/prepare_as_destination.rs
+++ b/dbcrossbarlib/src/drivers/gs/prepare_as_destination.rs
@@ -1,8 +1,6 @@
 //! Preparing bucket directories as output destinations.
 
-use std::process::Stdio;
-use tokio::process::Command;
-
+use crate::clouds::gcloud::storage;
 use crate::common::*;
 
 /// Prepare the target of this locator for use as a destination.
@@ -13,30 +11,7 @@ pub(crate) async fn prepare_as_destination_helper(
 ) -> Result<()> {
     // Delete the existing output, if it exists.
     if if_exists == IfExists::Overwrite {
-        // Delete all the files under `self.url`, but be careful not to
-        // delete the entire bucket. See `gsutil rm --help` for details.
-        debug!(ctx.log(), "deleting existing {}", gs_url);
-        if !gs_url.path().ends_with('/') {
-            return Err(format_err!(
-                "can only write to gs:// URL ending in '/', got {}",
-                gs_url,
-            ));
-        }
-        let delete_url = gs_url.join("**")?;
-        let status = Command::new("gsutil")
-            .args(&["rm", "-f", delete_url.as_str()])
-            // Throw away stdout so it doesn't corrupt our output.
-            .stdout(Stdio::null())
-            .status()
-            .await
-            .context("error running gsutil")?;
-        if !status.success() {
-            warn!(
-                ctx.log(),
-                "can't delete contents of {}, possibly because it doesn't exist",
-                gs_url,
-            );
-        }
+        storage::rmdir(&ctx, &gs_url).await?;
         Ok(())
     } else {
         Err(format_err!(

--- a/dbcrossbarlib/src/drivers/gs/write_local_data.rs
+++ b/dbcrossbarlib/src/drivers/gs/write_local_data.rs
@@ -1,11 +1,8 @@
 //! Writing data to Google Cloud Storage.
 
-use std::process::Stdio;
-use tokio::process::Command;
-
 use super::{prepare_as_destination_helper, GsLocator};
+use crate::clouds::gcloud::storage;
 use crate::common::*;
-use crate::tokio_glue::copy_stream_to_writer;
 
 /// Implementation of `write_local_data`, but as a real `async` function.
 pub(crate) async fn write_local_data_helper(
@@ -31,31 +28,8 @@ pub(crate) async fn write_local_data_helper(
             let ctx = ctx
                 .child(o!("stream" => stream.name.clone(), "url" => url.to_string()));
 
-            // Run `gsutil cp - $URL` as a background process.
-            debug!(ctx.log(), "uploading stream to gsutil");
-            let mut child = Command::new("gsutil")
-                .args(&["cp", "-", url.as_str()])
-                .stdin(Stdio::piped())
-                // Throw away stdout so it doesn't corrupt our output.
-                .stdout(Stdio::null())
-                .spawn()
-                .context("error running gsutil")?;
-            let child_stdin = child.stdin.take().expect("child should have stdin");
-
-            // Copy data to our child process.
-            copy_stream_to_writer(ctx.clone(), stream.data, child_stdin)
-                .await
-                .context("error copying data to gsutil")?;
-
-            // Wait for `gsutil` to finish.
-            let status = child
-                .await
-                .with_context(|_| format!("error finishing upload to {}", url))?;
-            if status.success() {
-                Ok(GsLocator { url }.boxed())
-            } else {
-                Err(format_err!("gsutil returned error: {}", status))
-            }
+            storage::upload_file(ctx.clone(), stream.data, &url).await?;
+            Ok(GsLocator { url }.boxed())
         }
         .boxed()
     });

--- a/dbcrossbarlib/src/lib.rs
+++ b/dbcrossbarlib/src/lib.rs
@@ -15,6 +15,7 @@ extern crate diesel;
 use std::result;
 
 pub(crate) mod args;
+pub(crate) mod clouds;
 pub(crate) mod concat;
 pub(crate) mod context;
 pub(crate) mod csv_stream;

--- a/dbcrossbarlib/src/rechunk.rs
+++ b/dbcrossbarlib/src/rechunk.rs
@@ -91,9 +91,8 @@ pub fn rechunk_csvs(
         };
         let mut chunk = new_chunk()?;
 
-        for row in rdr.byte_records() {
-            let row = row.context("cannot read row")?;
-
+        let mut row = csv::ByteRecord::new();
+        while rdr.read_byte_record(&mut row).context("cannot read row")? {
             // If this is the first row we've seen, we can safely send our
             // `CsvStream` to our `csv_stream_sender: BoxStream<CsvStream>`. We
             // do this before writing any data, including the headers, so that


### PR DESCRIPTION
This is the first part of the work on fixing `--stream-size` to behave better when passed many 40 MB CSV files from BigQuery. It includes:

1. A performance optimization in the `--stream-size` CSV reading code.
2. A refactoring which isolates `bq` and `gsutil` from the rest of the code, so that we can someday replace them.

I'm proposing this PR now, because (2) is also needed for fixing https://github.com/faradayio/dbcrossbar/issues/45.