### PR TITLE
bigquery: Honor `NOT NULL` on import (fixes #45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,33 +71,6 @@ curl https://sh.rustup.rs -sSf | sh
 cargo install -f --git https://github.com/faradayio/dbcrossbar dbcrossbar
 ```
 
-## Examples
-
-Run `dbcrossbar --help` for more documentation.
-
-```sh
-# Given a `postgres:` URL, dump a table schema as JSON.
-dbcrossbar "$DATABASE_URL#mytable" > schema.json
-
-# Dump a table schema as BigQuery schema JSON.
-dbcrossbar "$DATABASE_URL#mytable" -O bq:schema > bigquery-schema.json
-
-# Ditto, but using PostgreSQL `CREATE TABLE` SQL as input.
-dbcrossbar -I pg -O bq:schema < table.sql > bigquery-schema.json
-
-# Dump a table schema as quoted PostgreSQL `SELECT ...` arguments.
-dbcrossbar "$DATABASE_URL#mytable" -O pg:select > select-args.txt
-```
-
-You can also edit the default schema JSON (generated with no `-O` flag, or with `-O json`), and then run it back through to generate another format:
-
-```sh
-dbcrossbar "$DATABASE_URL#mytable" > schema.json
-# (Edit schema.json.)
-
-dbcrossbar -O bq < schema.json > bigquery-schema.json
-```
-
 ## "Interchange" table schemas
 
 In order to make `dbcrossbar` work, we define a "interchange" table schema format using JSON. This format uses a highly-simplied and carefully curated set of column data types that make sense when passing data between databases. This represents a compromise between the richness of PostgreSQL data types, and the relative poverty of BigQuery data types, while still preserving as much information as possible. It includes timestamps, geodata, etc.

--- a/dbcrossbarlib/src/clouds/gcloud/bigquery.rs
+++ b/dbcrossbarlib/src/clouds/gcloud/bigquery.rs
@@ -191,39 +191,6 @@ pub(crate) async fn load(
     }
 }
 
-pub(crate) async fn create_table_if_not_exists(
-    ctx: &Context,
-    dest_table: &BqTable,
-) -> Result<()> {
-    debug!(ctx.log(), "making sure table {} exists", dest_table.name(),);
-    let tmp_dir = TempDir::new("bq_mk")?;
-    let dest_schema_path = tmp_dir.path().join("schema.json");
-    let mut dest_schema_file = File::create(&dest_schema_path)?;
-    dest_table.write_json_schema(&mut dest_schema_file)?;
-    let mk_child = Command::new("bq")
-        // Use `--force` to ignore existing tables.
-        .args(&[
-            "mk",
-            "--headless",
-            "--force",
-            "--schema",
-            // --project_id actually makes this fail for some reason.
-        ])
-        // Pass separately, because paths may not be UTF-8.
-        .arg(&dest_schema_path)
-        .arg(&dest_table.name().to_string())
-        // Throw away stdout so it doesn't corrupt our output.
-        .stdout(Stdio::null())
-        .spawn()
-        .context("error starting `bq mk`")?;
-    let status = mk_child.await.context("error running `bq mk`")?;
-    if status.success() {
-        Ok(())
-    } else {
-        Err(format_err!("`bq mk` failed with {}", status))
-    }
-}
-
 /// Drop a table from BigQuery.
 pub(crate) async fn drop_table(ctx: &Context, table_name: &TableName) -> Result<()> {
     // Delete temp table.

--- a/dbcrossbarlib/src/drivers/bigquery_shared/column.rs
+++ b/dbcrossbarlib/src/drivers/bigquery_shared/column.rs
@@ -109,6 +109,14 @@ impl BqColumn {
         self.ty.to_bq_data_type(self.mode, &self.fields)
     }
 
+    /// Should this column be declared as `NOT NULL` when generating a `CREATE TABLE`?
+    pub(crate) fn is_not_null(&self) -> bool {
+        match &self.mode {
+            Mode::Required => true,
+            Mode::Repeated | Mode::Nullable => false,
+        }
+    }
+
     /// Convert this column into a struct field. We use this to implement
     /// `RECORD` column parsing.
     pub(crate) fn to_struct_field(&self) -> Result<BqStructField> {
@@ -171,7 +179,6 @@ return "#,
                     f,
                     r#";
 """;
-
 "#
                 )?;
             }

--- a/dbcrossbarlib/src/drivers/bigquery_shared/table.rs
+++ b/dbcrossbarlib/src/drivers/bigquery_shared/table.rs
@@ -181,7 +181,7 @@ impl BqTable {
             IfExists::Error => CreateTableType::Plain,
             IfExists::Overwrite => CreateTableType::OrReplace,
         };
-        self.write_create_table(create_table_type, f)?;
+        self.write_create_table_sql(create_table_type, f)?;
         writeln!(f)?;
 
         match if_exists {
@@ -197,7 +197,7 @@ impl BqTable {
     }
 
     /// Write a CREATE TABLE statement for this table.
-    fn write_create_table(
+    fn write_create_table_sql(
         &self,
         create_table_type: CreateTableType,
         f: &mut dyn Write,
@@ -302,8 +302,7 @@ impl BqTable {
         // Generate our actual SQL.
         writeln!(
             f,
-            r#"
-MERGE INTO {dest_table} AS dest
+            r#"MERGE INTO {dest_table} AS dest
 USING {temp_table} AS temp
 ON
     {key_comparisons}

--- a/dbcrossbarlib/src/drivers/bigquery_shared/table.rs
+++ b/dbcrossbarlib/src/drivers/bigquery_shared/table.rs
@@ -182,7 +182,7 @@ impl BqTable {
             IfExists::Overwrite => CreateTableType::OrReplace,
         };
         self.write_create_table(create_table_type, f)?;
-        writeln!(f, "")?;
+        writeln!(f)?;
 
         match if_exists {
             IfExists::Append | IfExists::Error | IfExists::Overwrite => {
@@ -213,7 +213,7 @@ impl BqTable {
         // Write the columns.
         for (i, col) in self.columns.iter().enumerate() {
             if i > 0 {
-                write!(f, ",\n")?;
+                writeln!(f, ",")?;
             }
             write!(f, "    {} {}", col.name, col.bq_data_type()?)?;
             if col.is_not_null() {

--- a/dbcrossbarlib/src/drivers/bigquery_shared/table.rs
+++ b/dbcrossbarlib/src/drivers/bigquery_shared/table.rs
@@ -5,6 +5,7 @@ use serde_json;
 use std::{
     collections::{HashMap, HashSet},
     convert::TryFrom,
+    fmt,
     iter::FromIterator,
 };
 
@@ -12,6 +13,27 @@ use super::{BqColumn, ColumnBigQueryExt, ColumnName, TableName, Usage};
 use crate::clouds::gcloud::bigquery;
 use crate::common::*;
 use crate::schema::{Column, Table};
+
+/// Which version of CREATE TABLE do we want to use?
+#[derive(Clone, Copy)]
+enum CreateTableType {
+    /// Regular `CREATE TABLE`.
+    Plain,
+    /// `CREATE TABLE IF NOT EXISTS`.
+    IfNotExists,
+    /// `CREATE OR REPLACE TABLE`.
+    OrReplace,
+}
+
+impl fmt::Display for CreateTableType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            CreateTableType::Plain => write!(f, "CREATE TABLE"),
+            CreateTableType::IfNotExists => write!(f, "CREATE TABLE IF NOT EXISTS"),
+            CreateTableType::OrReplace => write!(f, "CREATE OR REPLACE TABLE"),
+        }
+    }
+}
 
 /// Extensions to `Column` (the portable version) to handle BigQuery-query
 /// specific stuff.
@@ -138,18 +160,88 @@ impl BqTable {
         Ok(())
     }
 
+    /// Generate SQL which imports data from a temp table into a final
+    /// destination table, fixing any columns that couldn't be directly imported
+    /// from CSVs.
+    pub(crate) fn write_import_sql(
+        &self,
+        source_table_name: &TableName,
+        if_exists: &IfExists,
+        f: &mut dyn Write,
+    ) -> Result<()> {
+        // Write out any helper functions we'll need to transform data.
+        for (idx, col) in self.columns.iter().enumerate() {
+            col.write_import_udf(f, idx)?;
+        }
+
+        // Create the table with appropriate options. We do this explicitly so
+        // that we preserve the NULLABLE property of each column.
+        let create_table_type = match if_exists {
+            IfExists::Append | IfExists::Upsert(_) => CreateTableType::IfNotExists,
+            IfExists::Error => CreateTableType::Plain,
+            IfExists::Overwrite => CreateTableType::OrReplace,
+        };
+        self.write_create_table(create_table_type, f)?;
+        writeln!(f, "")?;
+
+        match if_exists {
+            IfExists::Append | IfExists::Error | IfExists::Overwrite => {
+                self.write_insert_sql(source_table_name, f)?;
+            }
+            IfExists::Upsert(merge_keys) => {
+                self.write_merge_sql(source_table_name, merge_keys, f)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Write a CREATE TABLE statement for this table.
+    fn write_create_table(
+        &self,
+        create_table_type: CreateTableType,
+        f: &mut dyn Write,
+    ) -> Result<()> {
+        // Write the appropriate CREATE TABLE part.
+        writeln!(
+            f,
+            "{} {} (",
+            create_table_type,
+            self.name.dotted_and_quoted()
+        )?;
+
+        // Write the columns.
+        for (i, col) in self.columns.iter().enumerate() {
+            if i > 0 {
+                write!(f, ",\n")?;
+            }
+            write!(f, "    {} {}", col.name, col.bq_data_type()?)?;
+            if col.is_not_null() {
+                write!(f, " NOT NULL")?;
+            }
+        }
+
+        // Write the footer.
+        writeln!(f, "\n);")?;
+        Ok(())
+    }
+
     /// Generate SQL which `SELECT`s from a temp table, and fixes the types
     /// of columns that couldn't be imported from CSVs.
     ///
     /// This `BqTable` should have been created with `Usage::FinalTable`.
-    pub(crate) fn write_import_sql(
+    fn write_insert_sql(
         &self,
         source_table_name: &TableName,
         f: &mut dyn Write,
     ) -> Result<()> {
-        for (i, col) in self.columns.iter().enumerate() {
-            col.write_import_udf(f, i)?;
-        }
+        // We always specify what columns we're inserting into, just to be safe.
+        writeln!(
+            f,
+            "INSERT INTO {} ({})",
+            self.name.dotted_and_quoted(),
+            self.columns.iter().map(|c| &c.name).join(","),
+        )?;
         write!(f, "SELECT ")?;
         for (i, col) in self.columns.iter().enumerate() {
             if i > 0 {
@@ -157,12 +249,12 @@ impl BqTable {
             }
             col.write_import_select_expr(f, i)?;
         }
-        write!(f, " FROM {}", source_table_name.dotted_and_quoted())?;
+        writeln!(f, "\nFROM {};", source_table_name.dotted_and_quoted())?;
         Ok(())
     }
 
     /// Generate a `MERGE INTO` statement using the specified columns.
-    pub(crate) fn write_merge_sql(
+    fn write_merge_sql(
         &self,
         source_table_name: &TableName,
         merge_keys: &[String],
@@ -199,11 +291,6 @@ impl BqTable {
         let merge_key_table =
             merge_keys.iter().map(|c| &c.name).collect::<HashSet<_>>();
 
-        // Write out any helper functions we'll need to transform data.
-        for (idx, col) in self.columns.iter().enumerate() {
-            col.write_import_udf(f, idx)?;
-        }
-
         // A helper function to generate import SQL for a column.
         let col_import_expr = |c: &BqColumn, idx: usize| -> String {
             let mut buf = vec![];
@@ -213,7 +300,7 @@ impl BqTable {
         };
 
         // Generate our actual SQL.
-        write!(
+        writeln!(
             f,
             r#"
 MERGE INTO {dest_table} AS dest
@@ -226,7 +313,7 @@ WHEN NOT MATCHED THEN INSERT (
     {columns}
 ) VALUES (
     {values}
-)"#,
+);"#,
             dest_table = self.name().dotted_and_quoted(),
             temp_table = source_table_name.dotted_and_quoted(),
             key_comparisons = merge_keys


### PR DESCRIPTION
For imports that required a custom SELECT to fix up the data, we used to
lose `NOT NULL` declarations on the columns, because we used `SELECT` to
create the destination table, and there's no way to represent `NOT
NULL`.

This patch rips all that out and replaces it with multi-statement SQL
scripts that include explicit `CREATE TABLE` statements.

This cleans up a bunch of dodgy logic in `bigquery::write_remote_data`
that I didn't really like. The whole business with `if_exists` and
upserts is now less hackish.